### PR TITLE
Add CoinMarketCap API proxy endpoints and update client

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -98,6 +98,101 @@ app.get("/api/proxy/coinmarketcap/global-metrics", async (req, res) => {
   }
 });
 
+app.get("/api/proxy/coinmarketcap/info", async (req, res) => {
+  try {
+    const { symbol, id } = req.query;
+    let queryParams = "";
+
+    if (symbol) {
+      queryParams = `symbol=${symbol}`;
+    } else if (id) {
+      queryParams = `id=${id}`;
+    } else {
+      return res
+        .status(400)
+        .json({ error: "Either 'symbol' or 'id' parameter is required" });
+    }
+
+    const response = await fetch(
+      `https://pro-api.coinmarketcap.com/v1/cryptocurrency/info?${queryParams}`,
+      {
+        headers: {
+          "X-CMC_PRO_API_KEY": COINMARKETCAP_API_KEY,
+          Accept: "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    res.json(data);
+  } catch (error) {
+    console.error("CoinMarketCap API Error:", error);
+    res.status(500).json({ error: "Failed to fetch cryptocurrency info" });
+  }
+});
+
+app.get("/api/proxy/coinmarketcap/map", async (req, res) => {
+  try {
+    const { symbol, listing_status = "active" } = req.query;
+    let queryParams = `listing_status=${listing_status}`;
+
+    if (symbol) {
+      queryParams += `&symbol=${symbol}`;
+    }
+
+    const response = await fetch(
+      `https://pro-api.coinmarketcap.com/v1/cryptocurrency/map?${queryParams}`,
+      {
+        headers: {
+          "X-CMC_PRO_API_KEY": COINMARKETCAP_API_KEY,
+          Accept: "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    res.json(data);
+  } catch (error) {
+    console.error("CoinMarketCap API Error:", error);
+    res.status(500).json({ error: "Failed to search cryptocurrencies" });
+  }
+});
+
+app.get("/api/proxy/coinmarketcap/trending", async (req, res) => {
+  try {
+    const { limit = 10, time_period = "24h" } = req.query;
+    const response = await fetch(
+      `https://pro-api.coinmarketcap.com/v1/cryptocurrency/trending/latest?limit=${limit}&time_period=${time_period}`,
+      {
+        headers: {
+          "X-CMC_PRO_API_KEY": COINMARKETCAP_API_KEY,
+          Accept: "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    res.json(data);
+  } catch (error) {
+    console.error("CoinMarketCap API Error:", error);
+    res
+      .status(500)
+      .json({ error: "Failed to fetch trending cryptocurrencies" });
+  }
+});
+
 // NewsAPI Proxy Endpoints
 app.get("/api/proxy/newsapi/top-headlines", async (req, res) => {
   try {

--- a/src/hooks/useCoinMarketCap.ts
+++ b/src/hooks/useCoinMarketCap.ts
@@ -55,74 +55,82 @@ export function useCryptoQuotes(
   const fetchQuotes = useCallback(async () => {
     if (!enabled || symbols.length === 0) return;
 
-    // CoinMarketCap API doesn't support CORS for browser requests
-    // Always use mock data in browser environment
-    console.warn(
-      "CoinMarketCap API requires server-side implementation due to CORS restrictions. Using mock data.",
-    );
-
     setLoading(true);
     setError(null);
 
-    // Generate mock data for crypto symbols
-    const mockTickers = stockDataFallback.getMockTickers(symbols);
-    const mockData: CoinMarketCapQuotesResponse = {
-      status: {
-        timestamp: new Date().toISOString(),
-        error_code: 0,
-        error_message: null,
-        elapsed: 0,
-        credit_count: 0,
-        notice: null,
-      },
-      data: {},
-    };
+    try {
+      // Use the CoinMarketCap service which now proxies through our server
+      const { coinMarketCapApi } = await import("../services/coinMarketCapApi");
+      const response = await coinMarketCapApi.getQuotesBySymbol(symbols);
 
-    mockTickers.forEach((ticker) => {
-      if (ticker.type === "crypto" || symbols.includes(ticker.symbol)) {
-        mockData.data[ticker.symbol] = {
-          id: Math.floor(Math.random() * 10000),
-          name: ticker.name,
-          symbol: ticker.symbol,
-          slug: ticker.symbol.toLowerCase(),
-          num_market_pairs: Math.floor(Math.random() * 1000),
-          date_added: "2021-01-01T00:00:00.000Z",
-          tags: ["cryptocurrency"],
-          max_supply: 0,
-          circulating_supply: Math.floor(Math.random() * 1000000000),
-          total_supply: Math.floor(Math.random() * 1000000000),
-          is_active: 1,
-          is_fiat: 0,
-          cmc_rank: Math.floor(Math.random() * 100) + 1,
-          last_updated: new Date().toISOString(),
-          quote: {
-            USD: {
-              price: ticker.price,
-              volume_24h: ticker.volume,
-              volume_change_24h: (Math.random() - 0.5) * 20,
-              percent_change_1h: (Math.random() - 0.5) * 5,
-              percent_change_24h: ticker.changePercent,
-              percent_change_7d: (Math.random() - 0.5) * 30,
-              percent_change_30d: (Math.random() - 0.5) * 50,
-              percent_change_60d: (Math.random() - 0.5) * 80,
-              percent_change_90d: (Math.random() - 0.5) * 100,
-              market_cap: ticker.marketCap || ticker.price * 1000000,
-              market_cap_dominance: Math.random() * 50,
-              fully_diluted_market_cap:
-                (ticker.marketCap || ticker.price * 1000000) * 1.1,
-              tvl: 0,
-              last_updated: new Date().toISOString(),
+      setData(response);
+      setError(null);
+    } catch (error) {
+      console.error("Failed to fetch crypto quotes:", error);
+
+      // Fallback to mock data if API fails
+      const mockTickers = stockDataFallback.getMockTickers(symbols);
+      const mockData: CoinMarketCapQuotesResponse = {
+        status: {
+          timestamp: new Date().toISOString(),
+          error_code: 0,
+          error_message: null,
+          elapsed: 0,
+          credit_count: 0,
+          notice: null,
+        },
+        data: {},
+      };
+
+      mockTickers.forEach((ticker) => {
+        if (ticker.type === "crypto" || symbols.includes(ticker.symbol)) {
+          mockData.data[ticker.symbol] = {
+            id: Math.floor(Math.random() * 10000),
+            name: ticker.name,
+            symbol: ticker.symbol,
+            slug: ticker.symbol.toLowerCase(),
+            num_market_pairs: Math.floor(Math.random() * 1000),
+            date_added: "2021-01-01T00:00:00.000Z",
+            tags: ["cryptocurrency"],
+            max_supply: 0,
+            circulating_supply: Math.floor(Math.random() * 1000000000),
+            total_supply: Math.floor(Math.random() * 1000000000),
+            is_active: 1,
+            is_fiat: 0,
+            cmc_rank: Math.floor(Math.random() * 100) + 1,
+            last_updated: new Date().toISOString(),
+            quote: {
+              USD: {
+                price: ticker.price,
+                volume_24h: ticker.volume,
+                volume_change_24h: (Math.random() - 0.5) * 20,
+                percent_change_1h: (Math.random() - 0.5) * 5,
+                percent_change_24h: ticker.changePercent,
+                percent_change_7d: (Math.random() - 0.5) * 30,
+                percent_change_30d: (Math.random() - 0.5) * 50,
+                percent_change_60d: (Math.random() - 0.5) * 80,
+                percent_change_90d: (Math.random() - 0.5) * 100,
+                market_cap: ticker.marketCap || ticker.price * 1000000,
+                market_cap_dominance: Math.random() * 50,
+                fully_diluted_market_cap:
+                  (ticker.marketCap || ticker.price * 1000000) * 1.1,
+                tvl: 0,
+                last_updated: new Date().toISOString(),
+              },
             },
-          },
-        };
-      }
-    });
+          };
+        }
+      });
 
-    setData(mockData);
-    setError(
-      "Using mock data - CoinMarketCap API requires server-side implementation (CORS restriction)",
-    );
-    setLoading(false);
+      setData(mockData);
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Failed to fetch cryptocurrency data - using fallback data",
+      );
+    } finally {
+      setLoading(false);
+    }
   }, [symbols, enabled]);
 
   useEffect(() => {

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -282,13 +282,10 @@ class CoinMarketCapService {
     limit: number = 10,
     timePeriod: "1h" | "24h" | "7d" | "30d" = "24h",
   ): Promise<CoinMarketCapListingsResponse> {
-    return this.fetchFromApi<CoinMarketCapListingsResponse>(
-      "/cryptocurrency/trending/latest",
-      {
-        limit: limit.toString(),
-        time_period: timePeriod,
-      },
-    );
+    return this.fetchFromApi<CoinMarketCapListingsResponse>("/trending", {
+      limit: limit.toString(),
+      time_period: timePeriod,
+    });
   }
 
   /**

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -196,15 +196,12 @@ class CoinMarketCapService {
     convert: string = "USD",
     sort: string = "market_cap",
   ): Promise<CoinMarketCapListingsResponse> {
-    return this.fetchFromApi<CoinMarketCapListingsResponse>(
-      "/cryptocurrency/listings/latest",
-      {
-        start: start.toString(),
-        limit: limit.toString(),
-        convert,
-        sort,
-      },
-    );
+    return this.fetchFromApi<CoinMarketCapListingsResponse>("/listings", {
+      start: start.toString(),
+      limit: limit.toString(),
+      convert,
+      sort,
+    });
   }
 
   /**

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -158,6 +158,15 @@ class CoinMarketCapService {
 
     try {
       const response = await fetch(url.toString());
+
+      // Check response status BEFORE consuming the body
+      if (!response.ok) {
+        throw new CoinMarketCapApiError(
+          `HTTP ${response.status}: ${response.statusText}`,
+          response.status,
+        );
+      }
+
       const data = await response.json();
 
       // Check for API errors
@@ -166,13 +175,6 @@ class CoinMarketCapService {
           data.status.error_message || "API request failed",
           data.status.error_code,
           "error",
-        );
-      }
-
-      if (!response.ok) {
-        throw new CoinMarketCapApiError(
-          `HTTP ${response.status}: ${response.statusText}`,
-          response.status,
         );
       }
 

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -224,13 +224,10 @@ class CoinMarketCapService {
     ids: number[],
     convert: string = "USD",
   ): Promise<CoinMarketCapQuotesResponse> {
-    return this.fetchFromApi<CoinMarketCapQuotesResponse>(
-      "/cryptocurrency/quotes/latest",
-      {
-        id: ids.join(","),
-        convert,
-      },
-    );
+    return this.fetchFromApi<CoinMarketCapQuotesResponse>("/quotes", {
+      id: ids.join(","),
+      convert,
+    });
   }
 
   /**

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -269,7 +269,7 @@ class CoinMarketCapService {
       }>;
     };
   }> {
-    return this.fetchFromApi("/cryptocurrency/map", {
+    return this.fetchFromApi("/map", {
       listing_status: "active",
       symbol: query,
     });

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -337,7 +337,7 @@ class CoinMarketCapService {
       last_updated: string;
     };
   }> {
-    return this.fetchFromApi("/global-metrics/quotes/latest", { convert });
+    return this.fetchFromApi("/global-metrics", { convert });
   }
 }
 

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -1,8 +1,8 @@
 // CoinMarketCap API Service
 // Documentation: https://coinmarketcap.com/api/documentation/v1/
+// Uses server proxy to avoid CORS restrictions
 
-const API_KEY = "a23f6083-9fcc-44d9-b03f-7cee769e3b91";
-const BASE_URL = "https://pro-api.coinmarketcap.com/v1";
+const BASE_URL = "/api/proxy/coinmarketcap";
 
 // CoinMarketCap API Response Types
 export interface CoinMarketCapQuote {

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -248,7 +248,7 @@ class CoinMarketCapService {
       params.id = ids.join(",");
     }
 
-    return this.fetchFromApi("/cryptocurrency/info", params);
+    return this.fetchFromApi("/info", params);
   }
 
   /**

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -211,13 +211,10 @@ class CoinMarketCapService {
     symbols: string[],
     convert: string = "USD",
   ): Promise<CoinMarketCapQuotesResponse> {
-    return this.fetchFromApi<CoinMarketCapQuotesResponse>(
-      "/cryptocurrency/quotes/latest",
-      {
-        symbol: symbols.join(","),
-        convert,
-      },
-    );
+    return this.fetchFromApi<CoinMarketCapQuotesResponse>("/quotes", {
+      symbol: symbols.join(","),
+      convert,
+    });
   }
 
   /**

--- a/src/services/coinMarketCapApi.ts
+++ b/src/services/coinMarketCapApi.ts
@@ -144,27 +144,20 @@ export class CoinMarketCapApiError extends Error {
 // API Service Class
 class CoinMarketCapService {
   private baseURL = BASE_URL;
-  private apiKey = API_KEY;
 
   private async fetchFromApi<T>(
     endpoint: string,
     params: Record<string, string> = {},
   ): Promise<T> {
-    const url = new URL(`${this.baseURL}${endpoint}`);
+    const url = new URL(`${this.baseURL}${endpoint}`, window.location.origin);
 
     // Add parameters
     Object.entries(params).forEach(([key, value]) => {
       url.searchParams.append(key, value);
     });
 
-    const headers = {
-      "X-CMC_PRO_API_KEY": this.apiKey,
-      Accept: "application/json",
-      "Accept-Encoding": "deflate, gzip",
-    };
-
     try {
-      const response = await fetch(url.toString(), { headers });
+      const response = await fetch(url.toString());
       const data = await response.json();
 
       // Check for API errors


### PR DESCRIPTION
Add three new CoinMarketCap API proxy endpoints to the server:
- `/api/proxy/coinmarketcap/info` - Get cryptocurrency info by symbol or ID
- `/api/proxy/coinmarketcap/map` - Search cryptocurrencies with optional symbol filter
- `/api/proxy/coinmarketcap/trending` - Get trending cryptocurrencies with configurable limit and time period

Update the client-side CoinMarketCap service to use the new proxy endpoints instead of direct API calls. This resolves CORS restrictions by routing requests through the server.

Modify the React hooks to attempt real API calls first, then fallback to mock data if the API fails. Remove hardcoded mock data usage and improve error handling throughout the cryptocurrency data fetching logic.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/30d4546200634294ad27021568e48b3a/cosmos-space)

👀 [Preview Link](https://30d4546200634294ad27021568e48b3a-cosmos-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>30d4546200634294ad27021568e48b3a</projectId>-->
<!--<branchName>cosmos-space</branchName>-->