### PR TITLE
Remove right sidebar and adjust left sidebar width

### DIFF
--- a/client/src/components/social/StockChannelHub.tsx
+++ b/client/src/components/social/StockChannelHub.tsx
@@ -511,42 +511,6 @@ export const StockChannelHub: React.FC = () => {
 
       {/* Right Sidebar (Optional) */}
       <div className="w-80 bg-gray-50 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 p-4 space-y-6">
-        {/* Trending Tickers */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm flex items-center gap-2">
-              <Flame className="w-4 h-4 text-orange-500" />
-              Trending Today
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {trendingTickers.map((ticker, index) => (
-              <div
-                key={ticker.ticker}
-                className="flex items-center justify-between"
-              >
-                <div>
-                  <div className="font-medium text-sm">${ticker.ticker}</div>
-                  <div className="text-xs text-gray-500">
-                    {ticker.companyName}
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div
-                    className={cn(
-                      "text-sm font-medium",
-                      ticker.change >= 0 ? "text-green-500" : "text-red-500",
-                    )}
-                  >
-                    {ticker.change >= 0 ? "+" : ""}
-                    {ticker.changePercent.toFixed(2)}%
-                  </div>
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-
         {/* Top Posters */}
         <Card>
           <CardHeader className="pb-3">

--- a/client/src/components/social/StockChannelHub.tsx
+++ b/client/src/components/social/StockChannelHub.tsx
@@ -265,7 +265,7 @@ export const StockChannelHub: React.FC = () => {
   return (
     <div className="flex h-[700px] bg-white dark:bg-gray-900 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
       {/* Left Sidebar - Stock Channels */}
-      <div className="w-96 bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col">
+      <div className="w-fit pr-[3%] max-w-[220px] bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col">
         {/* Sidebar Header */}
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">

--- a/client/src/components/social/StockChannelHub.tsx
+++ b/client/src/components/social/StockChannelHub.tsx
@@ -265,7 +265,7 @@ export const StockChannelHub: React.FC = () => {
   return (
     <div className="flex h-[700px] bg-white dark:bg-gray-900 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
       {/* Left Sidebar - Stock Channels */}
-      <div className="w-80 bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col">
+      <div className="w-96 bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col">
         {/* Sidebar Header */}
         <div className="p-4 border-b border-gray-200 dark:border-gray-700">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">

--- a/client/src/components/social/StockChannelHub.tsx
+++ b/client/src/components/social/StockChannelHub.tsx
@@ -510,42 +510,7 @@ export const StockChannelHub: React.FC = () => {
       </div>
 
       {/* Right Sidebar (Optional) */}
-      <div className="w-80 bg-gray-50 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 p-4 space-y-6">
-        {/* Hot Takes */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm flex items-center gap-2">
-              <Flame className="w-4 h-4 text-red-500" />
-              Hot Takes
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="text-xs space-y-2">
-              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded">
-                <div className="font-medium">🧠 Smart</div>
-                <div className="text-gray-600 dark:text-gray-400">
-                  "$TSLA ready for $300 breakout"
-                </div>
-                <div className="text-gray-500">47 votes</div>
-              </div>
-              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded">
-                <div className="font-medium">🚀 Moon</div>
-                <div className="text-gray-600 dark:text-gray-400">
-                  "AI revolution just getting started"
-                </div>
-                <div className="text-gray-500">32 votes</div>
-              </div>
-              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded">
-                <div className="font-medium">⚠️ Risky</div>
-                <div className="text-gray-600 dark:text-gray-400">
-                  "Overbought levels concern me"
-                </div>
-                <div className="text-gray-500">28 votes</div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <div className="w-80 bg-gray-50 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 p-4 space-y-6"></div>
     </div>
   );
 };

--- a/client/src/components/social/StockChannelHub.tsx
+++ b/client/src/components/social/StockChannelHub.tsx
@@ -511,38 +511,6 @@ export const StockChannelHub: React.FC = () => {
 
       {/* Right Sidebar (Optional) */}
       <div className="w-80 bg-gray-50 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 p-4 space-y-6">
-        {/* Sentiment Breakdown */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm flex items-center gap-2">
-              <Activity className="w-4 h-4 text-blue-500" />
-              Sentiment Breakdown
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="text-sm flex items-center gap-2">
-                  📈 Bullish
-                </span>
-                <span className="text-sm font-medium text-green-500">68%</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm flex items-center gap-2">
-                  📉 Bearish
-                </span>
-                <span className="text-sm font-medium text-red-500">18%</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm flex items-center gap-2">
-                  ⚖️ Neutral
-                </span>
-                <span className="text-sm font-medium text-gray-500">14%</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Hot Takes */}
         <Card>
           <CardHeader className="pb-3">

--- a/client/src/components/social/StockChannelHub.tsx
+++ b/client/src/components/social/StockChannelHub.tsx
@@ -508,9 +508,6 @@ export const StockChannelHub: React.FC = () => {
           </>
         )}
       </div>
-
-      {/* Right Sidebar (Optional) */}
-      <div className="w-80 bg-gray-50 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 p-4 space-y-6"></div>
     </div>
   );
 };

--- a/client/src/components/social/StockChannelHub.tsx
+++ b/client/src/components/social/StockChannelHub.tsx
@@ -511,36 +511,6 @@ export const StockChannelHub: React.FC = () => {
 
       {/* Right Sidebar (Optional) */}
       <div className="w-80 bg-gray-50 dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 p-4 space-y-6">
-        {/* Top Posters */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm flex items-center gap-2">
-              <Trophy className="w-4 h-4 text-yellow-500" />
-              Top Posters in ${selectedChannel?.ticker}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {topPosters.map((poster, index) => (
-              <div key={poster.username} className="flex items-center gap-3">
-                <div className="text-sm font-medium text-gray-500">
-                  #{index + 1}
-                </div>
-                <Avatar className="w-8 h-8">
-                  <AvatarImage src={poster.avatar} alt={poster.username} />
-                  <AvatarFallback>{poster.username[0]}</AvatarFallback>
-                </Avatar>
-                <div className="flex-1">
-                  <div className="text-sm font-medium">{poster.username}</div>
-                  <div className="text-xs text-gray-500">
-                    {poster.accuracy}% accuracy
-                  </div>
-                </div>
-                <div className="text-xs text-blue-600">{poster.points} pts</div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-
         {/* Sentiment Breakdown */}
         <Card>
           <CardHeader className="pb-3">


### PR DESCRIPTION
This change removes the entire right sidebar section from the StockChannelHub component and modifies the left sidebar styling.

Changes made:
- Removed the right sidebar div containing trending tickers, top posters, sentiment breakdown, and hot takes sections
- Updated left sidebar width from fixed `w-80` to responsive `w-fit pr-[3%] max-w-[220px]`
- Deleted approximately 140 lines of code related to the right sidebar content

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/a9397a9718dd41379408ce5c9431e5d8/vibe-hub)

👀 [Preview Link](https://a9397a9718dd41379408ce5c9431e5d8-vibe-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a9397a9718dd41379408ce5c9431e5d8</projectId>-->
<!--<branchName>vibe-hub</branchName>-->