### PR TITLE
Add Tool dropdown with tabs and new community sections

### DIFF
--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -404,7 +404,7 @@ export const FuturisticHomepage: React.FC = () => {
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
                                 ) : activeSection === 'tool' ? (
-                    <div></div>
+                                        <div></div>
 
             
                 

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -66,7 +66,7 @@ interface TrendingTopic {
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
-          const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tools'>('home');
+                    const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'market'>('home');
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   
   // Core mood data

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -67,6 +67,7 @@ export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
                                         const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool'>('home');
+      const [activeToolSubtab, setActiveToolSubtab] = useState("Market");
     const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -443,7 +443,7 @@ export const FuturisticHomepage: React.FC = () => {
                   </TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="Tools" className="mt-6">
+                                <TabsContent value="Market" className="mt-6">
                   <div className="space-y-6">
                     <div className="mb-6">
                       <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -416,32 +416,7 @@ export const FuturisticHomepage: React.FC = () => {
             {/* Tool Subtabs */}
             <div className="max-w-7xl mx-auto">
               <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
-                <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
-                  <TabsTrigger
-                    value="Market"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    📈 Market
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Analysis"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    📊 Analysis
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Scanner"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    🔍 Scanner
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Alerts"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    🔔 Alerts
-                  </TabsTrigger>
-                </TabsList>
+                
 
                                 <TabsContent value="Market" className="mt-6">
                   <div className="space-y-6">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -414,12 +414,7 @@ export const FuturisticHomepage: React.FC = () => {
 
                     
                       
-                        <TabsTrigger
-                          value="HeatMap"
-                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
-                        >
-                          📊 Heat Map
-                        </TabsTrigger>
+                        
                         <TabsTrigger
                           value="Analytics"
                           className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -249,7 +249,7 @@ export const FuturisticHomepage: React.FC = () => {
               </div>
               
               <nav className="hidden md:flex items-center gap-6">
-                                {['Home', 'Market Mood', 'Watchlist', 'News Feed'].map((item, index) => (
+                                                {['Home', 'Market Mood', 'Watchlist', 'News Feed', 'Tool'].map((item, index) => (
                                     <button
                     key={item}
                     onClick={() => {

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -413,56 +413,9 @@ export const FuturisticHomepage: React.FC = () => {
               </p>
             </div>
 
-                        {/* Tool Dropdown Menu */}
+            {/* Tool Subtabs */}
             <div className="max-w-7xl mx-auto">
-              <div className="mb-6">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className="w-64 justify-between bg-black/40 backdrop-blur-xl border-purple-500/20 text-white hover:bg-purple-500/20"
-                    >
-                      {activeToolSubtab === "Market" && "📈 Market"}
-                      {activeToolSubtab === "Analysis" && "📊 Analysis"}
-                      {activeToolSubtab === "Scanner" && "🔍 Scanner"}
-                      {activeToolSubtab === "Alerts" && "🔔 Alerts"}
-                      <ChevronDown className="h-4 w-4 opacity-50" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    className="w-64 bg-black/90 backdrop-blur-xl border-purple-500/30 text-white"
-                    align="start"
-                  >
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Market")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      📈 Market
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Analysis")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      📊 Analysis
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Scanner")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      🔍 Scanner
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Alerts")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      🔔 Alerts
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-
-              {/* Content based on dropdown selection */}
-              {activeToolSubtab === "Market" && (
+              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
                 <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
                   <TabsTrigger
                     value="Market"

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -28,6 +28,7 @@ import { WatchlistContainerBlock } from './watchlist/WatchlistContainerBlock';
 import { ChatInterface } from './moorMeter/ChatInterface';
 import { SpaceSwitcherWidget } from './community/SpaceSwitcherWidget';
 import { PrivateRoomsContainer } from './privateRooms/PrivateRoomsContainer';
+import { SentimentHeatMap } from './moorMeter/SentimentHeatMap';
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -66,7 +66,7 @@ interface TrendingTopic {
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
-                    const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'market'>('home');
+                              const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool'>('home');
     const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -454,14 +454,7 @@ export const FuturisticHomepage: React.FC = () => {
 
                       <TabsContent value="HeatMap" className="mt-6">
                         <div className="space-y-6">
-                          <div className="mb-6">
-                            <h3 className="text-xl font-bold text-white mb-2 flex items-center gap-2">
-                              📊 Market Heat Map
-                            </h3>
-                            <p className="text-gray-400">
-                              Visualize real-time sentiment movements across different stocks and timeframes
-                            </p>
-                          </div>
+                          
 
                           <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
                             <SentimentHeatMap />

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -413,7 +413,7 @@ export const FuturisticHomepage: React.FC = () => {
                   
 
                     
-                      <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
+                      
                         <TabsTrigger
                           value="HeatMap"
                           className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -399,7 +399,7 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
-        ) : activeSection === 'tools' ? (
+                ) : activeSection === 'tools' ? (
           <div className="space-y-6">
             {/* Tools Header */}
             <div className="text-center space-y-4">
@@ -411,20 +411,81 @@ export const FuturisticHomepage: React.FC = () => {
               </p>
             </div>
 
-            {/* Heat Map Section */}
+            {/* Tools Subtabs */}
             <div className="max-w-7xl mx-auto">
-              <div className="mb-6">
-                <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
-                  📊 Market Heat Map
-                </h2>
-                <p className="text-gray-400">
-                  Visualize real-time sentiment movements across different stocks and timeframes
-                </p>
-              </div>
+              <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
+                <TabsList className="grid w-full grid-cols-3 bg-black/40 backdrop-blur-xl border border-purple-500/20">
+                  <TabsTrigger
+                    value="HeatMap"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    📊 Heat Map
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Analytics"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    📈 Analytics
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Scanner"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    🔍 Scanner
+                  </TabsTrigger>
+                </TabsList>
 
-              <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
-                <SentimentHeatMap />
-              </div>
+                <TabsContent value="HeatMap" className="mt-6">
+                  <div className="space-y-6">
+                    <div className="mb-6">
+                      <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
+                        📊 Market Heat Map
+                      </h2>
+                      <p className="text-gray-400">
+                        Visualize real-time sentiment movements across different stocks and timeframes
+                      </p>
+                    </div>
+
+                    <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
+                      <SentimentHeatMap />
+                    </div>
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="Analytics" className="mt-6">
+                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                    <div className="text-center space-y-4">
+                      <div className="text-6xl mb-4">📈</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Advanced Analytics</h3>
+                      <p className="text-gray-400 mb-4">
+                        Comprehensive market analysis and trend insights coming soon.
+                      </p>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Technical Indicators</Badge>
+                        <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Trend Analysis</Badge>
+                        <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Volume Patterns</Badge>
+                      </div>
+                    </div>
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="Scanner" className="mt-6">
+                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                    <div className="text-center space-y-4">
+                      <div className="text-6xl mb-4">🔍</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
+                      <p className="text-gray-400 mb-4">
+                        Real-time stock and crypto scanner with custom filters and alerts.
+                      </p>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Price Alerts</Badge>
+                        <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Volume Spikes</Badge>
+                        <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Breakout Detection</Badge>
+                      </div>
+                    </div>
+                  </div>
+                </TabsContent>
+              </Tabs>
             </div>
           </div>
         ) : (

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -66,7 +66,7 @@ interface TrendingTopic {
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
-                                        const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool'>('home');
+                                                                                const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool' | 'market'>('home');
       const [activeToolSubtab, setActiveToolSubtab] = useState("Market");
     const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
@@ -249,7 +249,7 @@ export const FuturisticHomepage: React.FC = () => {
               </div>
               
               <nav className="hidden md:flex items-center gap-6">
-                                                {['Home', 'Market Mood', 'Watchlist', 'News Feed', 'Tool'].map((item, index) => (
+                                                                                                {['Home', 'Market Mood', 'Watchlist', 'News Feed'].map((item, index) => (
                                     <button
                     key={item}
                     onClick={() => {
@@ -263,8 +263,8 @@ export const FuturisticHomepage: React.FC = () => {
                         : "text-gray-400 hover:text-white"
                     )}
                                     >
-                    <span>
-                      {item === 'Tool' ? <p>Market</p> : item}
+                                        <span>
+                      {item}
                     </span>
                     {                      activeSection === item.toLowerCase().replace(' ', '-') && (
                       <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
@@ -327,22 +327,38 @@ export const FuturisticHomepage: React.FC = () => {
                                     </DropdownMenuContent>
                 </DropdownMenu>
 
-                                                {/* Tool Tab */}
-                <button
-                  onClick={() => setActiveSection('tool')}
-                  className={cn(
-                    "text-sm font-medium transition-all duration-300 relative group",
-                    activeSection === 'tool'
-                      ? "text-pink-400"
-                      : "text-gray-400 hover:text-white"
-                  )}
-                >
-                  Tool
-                  {activeSection === 'tool' && (
-                    <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
-                  )}
-                  <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-                </button>
+                                                                {/* Tool Dropdown */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className={cn(
+                        "text-sm font-medium transition-all duration-300 relative group flex items-center gap-1",
+                        activeSection === 'tool' || activeSection === 'market'
+                          ? "text-pink-400"
+                          : "text-gray-400 hover:text-white"
+                      )}
+                    >
+                      Tool
+                      <ChevronDown className="w-3 h-3" />
+                      {(activeSection === 'tool' || activeSection === 'market') && (
+                        <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
+                      )}
+                      <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="start"
+                    className="bg-black/90 backdrop-blur-xl border-purple-500/30 text-white"
+                  >
+                    <DropdownMenuItem
+                      onClick={() => setActiveSection('market')}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      <BarChart3 className="w-4 h-4 mr-2" />
+                      Market
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </nav>
             </div>
 
@@ -403,7 +419,7 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
-        ) : activeSection === 'tool' ? (
+                ) : activeSection === 'tool' || activeSection === 'market' ? (
           <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
             <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
               <TabsTrigger

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -318,8 +318,25 @@ export const FuturisticHomepage: React.FC = () => {
                       <MessageSquare className="w-4 h-4 mr-2" />
                       Chat
                     </DropdownMenuItem>
-                  </DropdownMenuContent>
+                                    </DropdownMenuContent>
                 </DropdownMenu>
+
+                {/* Tools Tab */}
+                <button
+                  onClick={() => setActiveSection('tools')}
+                  className={cn(
+                    "text-sm font-medium transition-all duration-300 relative group",
+                    activeSection === 'tools'
+                      ? "text-pink-400"
+                      : "text-gray-400 hover:text-white"
+                  )}
+                >
+                  Tools
+                  {activeSection === 'tools' && (
+                    <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
+                  )}
+                  <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                </button>
               </nav>
             </div>
 

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -65,8 +65,9 @@ interface TrendingTopic {
 
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
-  const [searchFocused, setSearchFocused] = useState(false);
+    const [searchFocused, setSearchFocused] = useState(false);
           const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tools'>('home');
+  const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   
   // Core mood data
   const [moodScore] = useState<MoodScore>({

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -65,7 +65,7 @@ interface TrendingTopic {
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
   const [searchFocused, setSearchFocused] = useState(false);
-        const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms'>('home');
+          const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tools'>('home');
   
   // Core mood data
   const [moodScore] = useState<MoodScore>({

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -401,21 +401,61 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
-                        ) : activeSection === 'market' ? (
+                                ) : activeSection === 'tool' ? (
           <div className="space-y-6">
-            {/* Market Header */}
+            {/* Tool Header */}
             <div className="text-center space-y-4">
               <h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
-                📈 Market
+                🔧 Tool
               </h1>
               <p className="text-xl text-gray-200 max-w-3xl mx-auto leading-relaxed">
-                Comprehensive market analysis, tools, and insights
+                Professional trading and analysis tools suite
               </p>
             </div>
 
-            {/* Market Subtabs */}
+            {/* Tool Subtabs */}
             <div className="max-w-7xl mx-auto">
-              <Tabs value={activeMarketSubtab} onValueChange={setActiveMarketSubtab}>
+              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
+                <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
+                  <TabsTrigger
+                    value="Market"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    📈 Market
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Analysis"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    📊 Analysis
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Scanner"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    🔍 Scanner
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Alerts"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    🔔 Alerts
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="Market" className="mt-6">
+                  <div className="space-y-6">
+                    <div className="mb-6">
+                      <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
+                        📈 Market Tools & Analysis
+                      </h2>
+                      <p className="text-gray-400">
+                        Comprehensive market analysis, tools, and insights
+                      </p>
+                    </div>
+
+                    {/* Market Sub-subtabs */}
+                    <Tabs value={activeMarketSubtab} onValueChange={setActiveMarketSubtab}>
                 <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
                   <TabsTrigger
                     value="Tools"
@@ -879,7 +919,7 @@ export const FuturisticHomepage: React.FC = () => {
             {/* Footer Status */}
             <div className="text-center">
               <Badge className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30">
-                Mood Score API: ✅ Live
+                Mood Score API: �� Live
               </Badge>
             </div>
                     </div>

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -66,9 +66,8 @@ interface TrendingTopic {
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
-                              const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool'>('home');
-      const [activeToolSubtab, setActiveToolSubtab] = useState("Market");
-  const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
+                    const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'market'>('home');
+    const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   
   // Core mood data
@@ -325,18 +324,18 @@ export const FuturisticHomepage: React.FC = () => {
                                     </DropdownMenuContent>
                 </DropdownMenu>
 
-                                                {/* Tool Tab */}
+                                {/* Market Tab */}
                 <button
-                  onClick={() => setActiveSection('tool')}
+                  onClick={() => setActiveSection('market')}
                   className={cn(
                     "text-sm font-medium transition-all duration-300 relative group",
-                    activeSection === 'tool'
+                    activeSection === 'market'
                       ? "text-pink-400"
                       : "text-gray-400 hover:text-white"
                   )}
                 >
-                  Tool
-                  {activeSection === 'tool' && (
+                  Market
+                  {activeSection === 'market' && (
                     <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
                   )}
                   <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
@@ -401,61 +400,21 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
-                                ) : activeSection === 'tool' ? (
+                        ) : activeSection === 'market' ? (
           <div className="space-y-6">
-            {/* Tool Header */}
+            {/* Market Header */}
             <div className="text-center space-y-4">
               <h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
-                🔧 Tool
+                📈 Market
               </h1>
               <p className="text-xl text-gray-200 max-w-3xl mx-auto leading-relaxed">
-                Professional trading and analysis tools suite
+                Comprehensive market analysis, tools, and insights
               </p>
             </div>
 
-            {/* Tool Subtabs */}
+            {/* Market Subtabs */}
             <div className="max-w-7xl mx-auto">
-              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
-                <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
-                  <TabsTrigger
-                    value="Market"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    📈 Market
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Analysis"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    📊 Analysis
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Scanner"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    🔍 Scanner
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Alerts"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    🔔 Alerts
-                  </TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="Market" className="mt-6">
-                  <div className="space-y-6">
-                    <div className="mb-6">
-                      <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
-                        📈 Market Tools & Analysis
-                      </h2>
-                      <p className="text-gray-400">
-                        Comprehensive market analysis, tools, and insights
-                      </p>
-                    </div>
-
-                    {/* Market Sub-subtabs */}
-                    <Tabs value={activeMarketSubtab} onValueChange={setActiveMarketSubtab}>
+              <Tabs value={activeMarketSubtab} onValueChange={setActiveMarketSubtab}>
                 <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
                   <TabsTrigger
                     value="Tools"
@@ -617,57 +576,6 @@ export const FuturisticHomepage: React.FC = () => {
                         <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">AI Analysis</Badge>
                         <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">Predictions</Badge>
                         <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">Sentiment</Badge>
-                      </div>
-                    </div>
-                  </div>
-                                </TabsContent>
-
-                <TabsContent value="Analysis" className="mt-6">
-                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                    <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">📊</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Advanced Analysis Suite</h3>
-                      <p className="text-gray-400 mb-4">
-                        Comprehensive technical and fundamental analysis tools.
-                      </p>
-                      <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Technical Analysis</Badge>
-                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Chart Patterns</Badge>
-                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Indicators</Badge>
-                      </div>
-                    </div>
-                  </div>
-                </TabsContent>
-
-                <TabsContent value="Scanner" className="mt-6">
-                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                    <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">🔍</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
-                      <p className="text-gray-400 mb-4">
-                        Real-time stock and crypto scanner with custom filters.
-                      </p>
-                      <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Price Alerts</Badge>
-                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Volume Spikes</Badge>
-                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Breakouts</Badge>
-                      </div>
-                    </div>
-                  </div>
-                </TabsContent>
-
-                <TabsContent value="Alerts" className="mt-6">
-                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                    <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">🔔</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Smart Alerts</h3>
-                      <p className="text-gray-400 mb-4">
-                        Intelligent alerts and notifications for trading opportunities.
-                      </p>
-                      <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Price Alerts</Badge>
-                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">News Alerts</Badge>
-                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Technical Signals</Badge>
                       </div>
                     </div>
                   </div>
@@ -970,7 +878,7 @@ export const FuturisticHomepage: React.FC = () => {
             {/* Footer Status */}
             <div className="text-center">
               <Badge className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30">
-                Mood Score API: �� Live
+                Mood Score API: ✅ Live
               </Badge>
             </div>
                     </div>

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -371,12 +371,14 @@ export const FuturisticHomepage: React.FC = () => {
             {/* Main Content */}
       <div className="relative z-10 max-w-7xl mx-auto px-6 py-8">
 
-                        {activeSection === 'watchlist' ? (
+                                {activeSection === 'watchlist' ? (
           <WatchlistContainerBlock />
         ) : activeSection === 'chat' ? (
           <ChatInterface />
         ) : activeSection === 'space' ? (
           <SpaceSwitcherWidget />
+        ) : activeSection === 'rooms' ? (
+          <PrivateRoomsContainer />
         ) : (
           <>
         

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -67,7 +67,8 @@ export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
                               const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool'>('home');
-    const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
+      const [activeToolSubtab, setActiveToolSubtab] = useState("Market");
+  const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   
   // Core mood data

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -531,52 +531,52 @@ export const FuturisticHomepage: React.FC = () => {
                   </div>
                 </TabsContent>
 
-                <TabsContent value="Overview" className="mt-6">
+                                <TabsContent value="Analysis" className="mt-6">
                   <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
                     <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">📋</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Market Overview</h3>
+                      <div className="text-6xl mb-4">📊</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Advanced Analysis Suite</h3>
                       <p className="text-gray-400 mb-4">
-                        Real-time market summary, indices, and key metrics.
+                        Comprehensive technical and fundamental analysis tools.
                       </p>
                       <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">Indices</Badge>
-                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">Sectors</Badge>
-                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">Top Movers</Badge>
+                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Technical Analysis</Badge>
+                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Chart Patterns</Badge>
+                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Indicators</Badge>
                       </div>
                     </div>
                   </div>
                 </TabsContent>
 
-                <TabsContent value="News" className="mt-6">
+                <TabsContent value="Scanner" className="mt-6">
                   <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
                     <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">📰</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Market News</h3>
+                      <div className="text-6xl mb-4">🔍</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
                       <p className="text-gray-400 mb-4">
-                        Latest market news, earnings reports, and financial updates.
+                        Real-time stock and crypto scanner with custom filters.
                       </p>
                       <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30">Breaking News</Badge>
-                        <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30">Earnings</Badge>
-                        <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30">Economic Data</Badge>
+                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Price Alerts</Badge>
+                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Volume Spikes</Badge>
+                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Breakouts</Badge>
                       </div>
                     </div>
                   </div>
                 </TabsContent>
 
-                <TabsContent value="Insights" className="mt-6">
+                <TabsContent value="Alerts" className="mt-6">
                   <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
                     <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">🧠</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">AI Market Insights</h3>
+                      <div className="text-6xl mb-4">🔔</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Smart Alerts</h3>
                       <p className="text-gray-400 mb-4">
-                        AI-powered market analysis, predictions, and trading insights.
+                        Intelligent alerts and notifications for trading opportunities.
                       </p>
                       <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">AI Analysis</Badge>
-                        <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">Predictions</Badge>
-                        <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">Sentiment</Badge>
+                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Price Alerts</Badge>
+                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">News Alerts</Badge>
+                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Technical Signals</Badge>
                       </div>
                     </div>
                   </div>

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -325,18 +325,18 @@ export const FuturisticHomepage: React.FC = () => {
                                     </DropdownMenuContent>
                 </DropdownMenu>
 
-                                {/* Market Tab */}
+                                                {/* Tool Tab */}
                 <button
-                  onClick={() => setActiveSection('market')}
+                  onClick={() => setActiveSection('tool')}
                   className={cn(
                     "text-sm font-medium transition-all duration-300 relative group",
-                    activeSection === 'market'
+                    activeSection === 'tool'
                       ? "text-pink-400"
                       : "text-gray-400 hover:text-white"
                   )}
                 >
-                  Market
-                  {activeSection === 'market' && (
+                  Tool
+                  {activeSection === 'tool' && (
                     <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
                   )}
                   <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button';
 import { Badge } from './ui/badge';
 import { Input } from './ui/input';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 import {
     Search,
   TrendingUp,

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -403,137 +403,69 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
-                                ) : activeSection === 'tool' ? (
-                                        <div></div>
+        ) : activeSection === 'tool' ? (
+          <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
+            <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
+              <TabsTrigger
+                value="HeatMap"
+                className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+              >
+                📊 Heat Map
+              </TabsTrigger>
+              <TabsTrigger
+                value="Analytics"
+                className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+              >
+                📈 Analytics
+              </TabsTrigger>
+              <TabsTrigger
+                value="Scanner"
+                className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+              >
+                🔍 Scanner
+              </TabsTrigger>
+            </TabsList>
 
-            
-                
+            <TabsContent value="HeatMap" className="mt-6">
+              <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
+                <SentimentHeatMap />
+              </div>
+            </TabsContent>
 
-                                
-                  
-
-                    
-                      <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
-                        <TabsTrigger
-                          value="HeatMap"
-                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
-                        >
-                          📊 Heat Map
-                        </TabsTrigger>
-                        <TabsTrigger
-                          value="Analytics"
-                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
-                        >
-                          📈 Analytics
-                        </TabsTrigger>
-                        <TabsTrigger
-                          value="Scanner"
-                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
-                        >
-                          🔍 Scanner
-                        </TabsTrigger>
-                      </TabsList>
-
-                      <TabsContent value="HeatMap" className="mt-6">
-                        <div className="space-y-6">
-                          
-
-                          <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
-                            <SentimentHeatMap />
-                          </div>
-                        </div>
-                      </TabsContent>
-
-                      <TabsContent value="Analytics" className="mt-6">
-                        <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                          <div className="text-center space-y-4">
-                            <div className="text-6xl mb-4">📈</div>
-                            <h3 className="text-2xl font-bold text-white mb-2">Advanced Analytics</h3>
-                            <p className="text-gray-400 mb-4">
-                              Comprehensive market analysis and trend insights coming soon.
-                            </p>
-                            <div className="flex flex-wrap gap-2 justify-center">
-                              <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Technical Indicators</Badge>
-                              <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Trend Analysis</Badge>
-                              <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Volume Patterns</Badge>
-                            </div>
-                          </div>
-                        </div>
-                      </TabsContent>
-
-                      <TabsContent value="Scanner" className="mt-6">
-                        <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                          <div className="text-center space-y-4">
-                            <div className="text-6xl mb-4">🔍</div>
-                            <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
-                            <p className="text-gray-400 mb-4">
-                              Real-time stock and crypto scanner with custom filters and alerts.
-                            </p>
-                            <div className="flex flex-wrap gap-2 justify-center">
-                              <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Price Alerts</Badge>
-                              <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Volume Spikes</Badge>
-                              <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Breakout Detection</Badge>
-                            </div>
-                          </div>
-                        </div>
-                      </TabsContent>
-                    </Tabs>
+            <TabsContent value="Analytics" className="mt-6">
+              <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                <div className="text-center space-y-4">
+                  <div className="text-6xl mb-4">📈</div>
+                  <h3 className="text-2xl font-bold text-white mb-2">Advanced Analytics</h3>
+                  <p className="text-gray-400 mb-4">
+                    Comprehensive market analysis and trend insights coming soon.
+                  </p>
+                  <div className="flex flex-wrap gap-2 justify-center">
+                    <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Technical Indicators</Badge>
+                    <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Trend Analysis</Badge>
+                    <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Volume Patterns</Badge>
                   </div>
-                </TabsContent>
+                </div>
+              </div>
+            </TabsContent>
 
-                                <TabsContent value="Analysis" className="mt-6">
-                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                    <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">📊</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Advanced Analysis Suite</h3>
-                      <p className="text-gray-400 mb-4">
-                        Comprehensive technical and fundamental analysis tools.
-                      </p>
-                      <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Technical Analysis</Badge>
-                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Chart Patterns</Badge>
-                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Indicators</Badge>
-                      </div>
-                    </div>
+            <TabsContent value="Scanner" className="mt-6">
+              <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                <div className="text-center space-y-4">
+                  <div className="text-6xl mb-4">🔍</div>
+                  <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
+                  <p className="text-gray-400 mb-4">
+                    Real-time stock and crypto scanner with custom filters and alerts.
+                  </p>
+                  <div className="flex flex-wrap gap-2 justify-center">
+                    <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Price Alerts</Badge>
+                    <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Volume Spikes</Badge>
+                    <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Breakout Detection</Badge>
                   </div>
-                </TabsContent>
-
-                <TabsContent value="Scanner" className="mt-6">
-                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                    <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">🔍</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
-                      <p className="text-gray-400 mb-4">
-                        Real-time stock and crypto scanner with custom filters.
-                      </p>
-                      <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Price Alerts</Badge>
-                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Volume Spikes</Badge>
-                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Breakouts</Badge>
-                      </div>
-                    </div>
-                  </div>
-                </TabsContent>
-
-                <TabsContent value="Alerts" className="mt-6">
-                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
-                    <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">🔔</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Smart Alerts</h3>
-                      <p className="text-gray-400 mb-4">
-                        Intelligent alerts and notifications for trading opportunities.
-                      </p>
-                      <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Price Alerts</Badge>
-                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">News Alerts</Badge>
-                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Technical Signals</Badge>
-                      </div>
-                    </div>
-                  </div>
-                </TabsContent>
-              </Tabs>
-            </div>
-          </div>
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
         ) : (
           <>
         

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -404,16 +404,7 @@ export const FuturisticHomepage: React.FC = () => {
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
                                 ) : activeSection === 'tool' ? (
-          <div className="space-y-6">
-                        {/* Tool Header */}
-            <div className="text-center space-y-4">
-              <h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
-                🔧 Tool
-              </h1>
-              <p className="text-xl text-gray-200 max-w-3xl mx-auto leading-relaxed">
-                Professional trading and analysis tools suite
-              </p>
-            </div>
+                    <div></div>
 
             {/* Tool Subtabs */}
             <div className="max-w-7xl mx-auto">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -296,12 +296,19 @@ export const FuturisticHomepage: React.FC = () => {
                       <Users className="w-4 h-4 mr-2" />
                       Community Forum
                     </DropdownMenuItem>
-                    <DropdownMenuItem
+                                        <DropdownMenuItem
                       onClick={() => setActiveSection('space')}
                       className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
                     >
                       <Users className="w-4 h-4 mr-2" />
                       Space
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveSection('rooms')}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      <Users className="w-4 h-4 mr-2" />
+                      Rooms
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       onClick={() => setActiveSection('chat')}

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -620,6 +620,57 @@ export const FuturisticHomepage: React.FC = () => {
                       </div>
                     </div>
                   </div>
+                                </TabsContent>
+
+                <TabsContent value="Analysis" className="mt-6">
+                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                    <div className="text-center space-y-4">
+                      <div className="text-6xl mb-4">📊</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Advanced Analysis Suite</h3>
+                      <p className="text-gray-400 mb-4">
+                        Comprehensive technical and fundamental analysis tools.
+                      </p>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Technical Analysis</Badge>
+                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Chart Patterns</Badge>
+                        <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Indicators</Badge>
+                      </div>
+                    </div>
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="Scanner" className="mt-6">
+                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                    <div className="text-center space-y-4">
+                      <div className="text-6xl mb-4">🔍</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
+                      <p className="text-gray-400 mb-4">
+                        Real-time stock and crypto scanner with custom filters.
+                      </p>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Price Alerts</Badge>
+                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Volume Spikes</Badge>
+                        <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Breakouts</Badge>
+                      </div>
+                    </div>
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="Alerts" className="mt-6">
+                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                    <div className="text-center space-y-4">
+                      <div className="text-6xl mb-4">🔔</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Smart Alerts</h3>
+                      <p className="text-gray-400 mb-4">
+                        Intelligent alerts and notifications for trading opportunities.
+                      </p>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Price Alerts</Badge>
+                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">News Alerts</Badge>
+                        <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Technical Signals</Badge>
+                      </div>
+                    </div>
+                  </div>
                 </TabsContent>
               </Tabs>
             </div>

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -413,35 +413,53 @@ export const FuturisticHomepage: React.FC = () => {
               </p>
             </div>
 
-            {/* Tool Subtabs */}
+                        {/* Tool Dropdown Menu */}
             <div className="max-w-7xl mx-auto">
-              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
-                <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
-                  <TabsTrigger
-                    value="Market"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+              <div className="mb-6">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-64 justify-between bg-black/40 backdrop-blur-xl border-purple-500/20 text-white hover:bg-purple-500/20"
+                    >
+                      {activeToolSubtab === "Market" && "📈 Market"}
+                      {activeToolSubtab === "Analysis" && "📊 Analysis"}
+                      {activeToolSubtab === "Scanner" && "🔍 Scanner"}
+                      {activeToolSubtab === "Alerts" && "🔔 Alerts"}
+                      <ChevronDown className="h-4 w-4 opacity-50" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className="w-64 bg-black/90 backdrop-blur-xl border-purple-500/30 text-white"
+                    align="start"
                   >
-                    📈 Market
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Analysis"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    📊 Analysis
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Scanner"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    🔍 Scanner
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="Alerts"
-                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
-                  >
-                    🔔 Alerts
-                  </TabsTrigger>
-                </TabsList>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Market")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      📈 Market
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Analysis")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      📊 Analysis
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Scanner")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      🔍 Scanner
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Alerts")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      🔔 Alerts
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
 
                                 <TabsContent value="Market" className="mt-6">
                   <div className="space-y-6">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -400,88 +400,182 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
-                ) : activeSection === 'tools' ? (
+                        ) : activeSection === 'market' ? (
           <div className="space-y-6">
-            {/* Tools Header */}
+            {/* Market Header */}
             <div className="text-center space-y-4">
               <h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
-                📊 Tools
+                📈 Market
               </h1>
               <p className="text-xl text-gray-200 max-w-3xl mx-auto leading-relaxed">
-                Advanced market analysis and visualization tools
+                Comprehensive market analysis, tools, and insights
               </p>
             </div>
 
-            {/* Tools Subtabs */}
+            {/* Market Subtabs */}
             <div className="max-w-7xl mx-auto">
-              <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
-                <TabsList className="grid w-full grid-cols-3 bg-black/40 backdrop-blur-xl border border-purple-500/20">
+              <Tabs value={activeMarketSubtab} onValueChange={setActiveMarketSubtab}>
+                <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
                   <TabsTrigger
-                    value="HeatMap"
+                    value="Tools"
                     className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    📊 Heat Map
+                    📊 Tools
                   </TabsTrigger>
                   <TabsTrigger
-                    value="Analytics"
+                    value="Overview"
                     className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    📈 Analytics
+                    📋 Overview
                   </TabsTrigger>
                   <TabsTrigger
-                    value="Scanner"
+                    value="News"
                     className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    🔍 Scanner
+                    📰 News
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Insights"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    🧠 Insights
                   </TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="HeatMap" className="mt-6">
+                <TabsContent value="Tools" className="mt-6">
                   <div className="space-y-6">
                     <div className="mb-6">
                       <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
-                        📊 Market Heat Map
+                        📊 Advanced Market Analysis Tools
                       </h2>
                       <p className="text-gray-400">
-                        Visualize real-time sentiment movements across different stocks and timeframes
+                        Professional tools for market analysis and visualization
                       </p>
                     </div>
 
-                    <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
-                      <SentimentHeatMap />
-                    </div>
+                    {/* Tools Sub-subtabs */}
+                    <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
+                      <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
+                        <TabsTrigger
+                          value="HeatMap"
+                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+                        >
+                          📊 Heat Map
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="Analytics"
+                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+                        >
+                          📈 Analytics
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="Scanner"
+                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+                        >
+                          🔍 Scanner
+                        </TabsTrigger>
+                      </TabsList>
+
+                      <TabsContent value="HeatMap" className="mt-6">
+                        <div className="space-y-6">
+                          <div className="mb-6">
+                            <h3 className="text-xl font-bold text-white mb-2 flex items-center gap-2">
+                              📊 Market Heat Map
+                            </h3>
+                            <p className="text-gray-400">
+                              Visualize real-time sentiment movements across different stocks and timeframes
+                            </p>
+                          </div>
+
+                          <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
+                            <SentimentHeatMap />
+                          </div>
+                        </div>
+                      </TabsContent>
+
+                      <TabsContent value="Analytics" className="mt-6">
+                        <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                          <div className="text-center space-y-4">
+                            <div className="text-6xl mb-4">📈</div>
+                            <h3 className="text-2xl font-bold text-white mb-2">Advanced Analytics</h3>
+                            <p className="text-gray-400 mb-4">
+                              Comprehensive market analysis and trend insights coming soon.
+                            </p>
+                            <div className="flex flex-wrap gap-2 justify-center">
+                              <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Technical Indicators</Badge>
+                              <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Trend Analysis</Badge>
+                              <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Volume Patterns</Badge>
+                            </div>
+                          </div>
+                        </div>
+                      </TabsContent>
+
+                      <TabsContent value="Scanner" className="mt-6">
+                        <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                          <div className="text-center space-y-4">
+                            <div className="text-6xl mb-4">🔍</div>
+                            <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
+                            <p className="text-gray-400 mb-4">
+                              Real-time stock and crypto scanner with custom filters and alerts.
+                            </p>
+                            <div className="flex flex-wrap gap-2 justify-center">
+                              <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Price Alerts</Badge>
+                              <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Volume Spikes</Badge>
+                              <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Breakout Detection</Badge>
+                            </div>
+                          </div>
+                        </div>
+                      </TabsContent>
+                    </Tabs>
                   </div>
                 </TabsContent>
 
-                <TabsContent value="Analytics" className="mt-6">
+                <TabsContent value="Overview" className="mt-6">
                   <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
                     <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">📈</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Advanced Analytics</h3>
+                      <div className="text-6xl mb-4">📋</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Market Overview</h3>
                       <p className="text-gray-400 mb-4">
-                        Comprehensive market analysis and trend insights coming soon.
+                        Real-time market summary, indices, and key metrics.
                       </p>
                       <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Technical Indicators</Badge>
-                        <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Trend Analysis</Badge>
-                        <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Volume Patterns</Badge>
+                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">Indices</Badge>
+                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">Sectors</Badge>
+                        <Badge className="bg-green-500/20 text-green-300 border-green-500/30">Top Movers</Badge>
                       </div>
                     </div>
                   </div>
                 </TabsContent>
 
-                <TabsContent value="Scanner" className="mt-6">
+                <TabsContent value="News" className="mt-6">
                   <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
                     <div className="text-center space-y-4">
-                      <div className="text-6xl mb-4">🔍</div>
-                      <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
+                      <div className="text-6xl mb-4">📰</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">Market News</h3>
                       <p className="text-gray-400 mb-4">
-                        Real-time stock and crypto scanner with custom filters and alerts.
+                        Latest market news, earnings reports, and financial updates.
                       </p>
                       <div className="flex flex-wrap gap-2 justify-center">
-                        <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Price Alerts</Badge>
-                        <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Volume Spikes</Badge>
-                        <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Breakout Detection</Badge>
+                        <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30">Breaking News</Badge>
+                        <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30">Earnings</Badge>
+                        <Badge className="bg-blue-500/20 text-blue-300 border-blue-500/30">Economic Data</Badge>
+                      </div>
+                    </div>
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="Insights" className="mt-6">
+                  <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                    <div className="text-center space-y-4">
+                      <div className="text-6xl mb-4">🧠</div>
+                      <h3 className="text-2xl font-bold text-white mb-2">AI Market Insights</h3>
+                      <p className="text-gray-400 mb-4">
+                        AI-powered market analysis, predictions, and trading insights.
+                      </p>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">AI Analysis</Badge>
+                        <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">Predictions</Badge>
+                        <Badge className="bg-pink-500/20 text-pink-300 border-pink-500/30">Sentiment</Badge>
                       </div>
                     </div>
                   </div>

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -403,43 +403,43 @@ export const FuturisticHomepage: React.FC = () => {
           <PrivateRoomsContainer />
                                 ) : activeSection === 'tool' ? (
           <div className="space-y-6">
-            {/* Market Header */}
+                        {/* Tool Header */}
             <div className="text-center space-y-4">
               <h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
-                📈 Market
+                🔧 Tool
               </h1>
               <p className="text-xl text-gray-200 max-w-3xl mx-auto leading-relaxed">
-                Comprehensive market analysis, tools, and insights
+                Professional trading and analysis tools suite
               </p>
             </div>
 
-            {/* Market Subtabs */}
+            {/* Tool Subtabs */}
             <div className="max-w-7xl mx-auto">
-              <Tabs value={activeMarketSubtab} onValueChange={setActiveMarketSubtab}>
+              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
                 <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
                   <TabsTrigger
-                    value="Tools"
+                    value="Market"
                     className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    📊 Tools
+                    📈 Market
                   </TabsTrigger>
                   <TabsTrigger
-                    value="Overview"
+                    value="Analysis"
                     className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    📋 Overview
+                    📊 Analysis
                   </TabsTrigger>
                   <TabsTrigger
-                    value="News"
+                    value="Scanner"
                     className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    📰 News
+                    🔍 Scanner
                   </TabsTrigger>
                   <TabsTrigger
-                    value="Insights"
+                    value="Alerts"
                     className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    🧠 Insights
+                    🔔 Alerts
                   </TabsTrigger>
                 </TabsList>
 

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -409,7 +409,7 @@ export const FuturisticHomepage: React.FC = () => {
             
                 
 
-                                <TabsContent value="Market" className="mt-6">
+                                
                   <div className="space-y-6">
                     <div className="mb-6">
                       <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -262,8 +262,10 @@ export const FuturisticHomepage: React.FC = () => {
                         ? "text-pink-400" 
                         : "text-gray-400 hover:text-white"
                     )}
-                  >
-                    {item}
+                                    >
+                    <span>
+                      {item === 'Tool' ? <p>Market</p> : item}
+                    </span>
                     {                      activeSection === item.toLowerCase().replace(' ', '-') && (
                       <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
                     )}

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -410,15 +410,7 @@ export const FuturisticHomepage: React.FC = () => {
                 
 
                                 
-                  <div className="space-y-6">
-                    <div className="mb-6">
-                      <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
-                        📊 Advanced Market Analysis Tools
-                      </h2>
-                      <p className="text-gray-400">
-                        Professional tools for market analysis and visualization
-                      </p>
-                    </div>
+                  
 
                     {/* Tools Sub-subtabs */}
                     <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -404,7 +404,7 @@ export const FuturisticHomepage: React.FC = () => {
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
                                 ) : activeSection === 'tool' ? (
-                                        <div></div>
+                    <div></div>
 
             
                 
@@ -413,8 +413,13 @@ export const FuturisticHomepage: React.FC = () => {
                   
 
                     
-                      
-                        
+                      <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
+                        <TabsTrigger
+                          value="HeatMap"
+                          className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+                        >
+                          📊 Heat Map
+                        </TabsTrigger>
                         <TabsTrigger
                           value="Analytics"
                           className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -324,18 +324,18 @@ export const FuturisticHomepage: React.FC = () => {
                                     </DropdownMenuContent>
                 </DropdownMenu>
 
-                {/* Tools Tab */}
+                                {/* Market Tab */}
                 <button
-                  onClick={() => setActiveSection('tools')}
+                  onClick={() => setActiveSection('market')}
                   className={cn(
                     "text-sm font-medium transition-all duration-300 relative group",
-                    activeSection === 'tools'
+                    activeSection === 'market'
                       ? "text-pink-400"
                       : "text-gray-400 hover:text-white"
                   )}
                 >
-                  Tools
-                  {activeSection === 'tools' && (
+                  Market
+                  {activeSection === 'market' && (
                     <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
                   )}
                   <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -413,9 +413,56 @@ export const FuturisticHomepage: React.FC = () => {
               </p>
             </div>
 
-            {/* Tool Subtabs */}
+                        {/* Tool Dropdown Menu */}
             <div className="max-w-7xl mx-auto">
-              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
+              <div className="mb-6">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-64 justify-between bg-black/40 backdrop-blur-xl border-purple-500/20 text-white hover:bg-purple-500/20"
+                    >
+                      {activeToolSubtab === "Market" && "📈 Market"}
+                      {activeToolSubtab === "Analysis" && "📊 Analysis"}
+                      {activeToolSubtab === "Scanner" && "🔍 Scanner"}
+                      {activeToolSubtab === "Alerts" && "🔔 Alerts"}
+                      <ChevronDown className="h-4 w-4 opacity-50" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className="w-64 bg-black/90 backdrop-blur-xl border-purple-500/30 text-white"
+                    align="start"
+                  >
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Market")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      📈 Market
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Analysis")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      📊 Analysis
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Scanner")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      🔍 Scanner
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Alerts")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      🔔 Alerts
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              {/* Content based on dropdown selection */}
+              {activeToolSubtab === "Market" && (
                 <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
                   <TabsTrigger
                     value="Market"

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -67,6 +67,7 @@ export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
                     const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'market'>('home');
+    const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   
   // Core mood data

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -389,7 +389,7 @@ export const FuturisticHomepage: React.FC = () => {
             {/* Main Content */}
       <div className="relative z-10 max-w-7xl mx-auto px-6 py-8">
 
-                                {activeSection === 'watchlist' ? (
+                                        {activeSection === 'watchlist' ? (
           <WatchlistContainerBlock />
         ) : activeSection === 'chat' ? (
           <ChatInterface />
@@ -397,6 +397,34 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
+        ) : activeSection === 'tools' ? (
+          <div className="space-y-6">
+            {/* Tools Header */}
+            <div className="text-center space-y-4">
+              <h1 className="text-4xl font-bold bg-gradient-to-r from-pink-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
+                📊 Tools
+              </h1>
+              <p className="text-xl text-gray-200 max-w-3xl mx-auto leading-relaxed">
+                Advanced market analysis and visualization tools
+              </p>
+            </div>
+
+            {/* Heat Map Section */}
+            <div className="max-w-7xl mx-auto">
+              <div className="mb-6">
+                <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
+                  📊 Market Heat Map
+                </h2>
+                <p className="text-gray-400">
+                  Visualize real-time sentiment movements across different stocks and timeframes
+                </p>
+              </div>
+
+              <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
+                <SentimentHeatMap />
+              </div>
+            </div>
+          </div>
         ) : (
           <>
         

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -461,7 +461,9 @@ export const FuturisticHomepage: React.FC = () => {
                 </DropdownMenu>
               </div>
 
-                                <TabsContent value="Market" className="mt-6">
+                                              {/* Content based on dropdown selection */}
+              {activeToolSubtab === "Market" && (
+                <div className="mt-6">
                   <div className="space-y-6">
                     <div className="mb-6">
                       <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -413,57 +413,37 @@ export const FuturisticHomepage: React.FC = () => {
               </p>
             </div>
 
-                        {/* Tool Dropdown Menu */}
+            {/* Tool Subtabs */}
             <div className="max-w-7xl mx-auto">
-              <div className="mb-6">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className="w-64 justify-between bg-black/40 backdrop-blur-xl border-purple-500/20 text-white hover:bg-purple-500/20"
-                    >
-                      {activeToolSubtab === "Market" && "📈 Market"}
-                      {activeToolSubtab === "Analysis" && "📊 Analysis"}
-                      {activeToolSubtab === "Scanner" && "🔍 Scanner"}
-                      {activeToolSubtab === "Alerts" && "🔔 Alerts"}
-                      <ChevronDown className="h-4 w-4 opacity-50" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    className="w-64 bg-black/90 backdrop-blur-xl border-purple-500/30 text-white"
-                    align="start"
+              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
+                <TabsList className="grid w-full grid-cols-4 bg-black/40 backdrop-blur-xl border border-purple-500/20">
+                  <TabsTrigger
+                    value="Market"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
                   >
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Market")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      📈 Market
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Analysis")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      📊 Analysis
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Scanner")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      🔍 Scanner
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setActiveToolSubtab("Alerts")}
-                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
-                    >
-                      🔔 Alerts
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+                    📈 Market
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Analysis"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    📊 Analysis
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Scanner"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    🔍 Scanner
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="Alerts"
+                    className="data-[state=active]:bg-purple-500/20 data-[state=active]:text-white text-gray-400"
+                  >
+                    🔔 Alerts
+                  </TabsTrigger>
+                </TabsList>
 
-                                              {/* Content based on dropdown selection */}
-              {activeToolSubtab === "Market" && (
-                <div className="mt-6">
+                                <TabsContent value="Market" className="mt-6">
                   <div className="space-y-6">
                     <div className="mb-6">
                       <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -412,8 +412,7 @@ export const FuturisticHomepage: React.FC = () => {
                                 
                   
 
-                    {/* Tools Sub-subtabs */}
-                    <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
+                    
                       <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
                         <TabsTrigger
                           value="HeatMap"

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -406,9 +406,7 @@ export const FuturisticHomepage: React.FC = () => {
                                 ) : activeSection === 'tool' ? (
                     <div></div>
 
-            {/* Tool Subtabs */}
-            <div className="max-w-7xl mx-auto">
-              <Tabs value={activeToolSubtab} onValueChange={setActiveToolSubtab}>
+            
                 
 
                                 <TabsContent value="Market" className="mt-6">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -66,7 +66,7 @@ interface TrendingTopic {
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
     const [searchFocused, setSearchFocused] = useState(false);
-                    const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'market'>('home');
+                                        const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool'>('home');
     const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
   

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -401,7 +401,7 @@ export const FuturisticHomepage: React.FC = () => {
           <SpaceSwitcherWidget />
         ) : activeSection === 'rooms' ? (
           <PrivateRoomsContainer />
-                        ) : activeSection === 'market' ? (
+                                ) : activeSection === 'tool' ? (
           <div className="space-y-6">
             {/* Market Header */}
             <div className="text-center space-y-4">

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -272,14 +272,14 @@ export const FuturisticHomepage: React.FC = () => {
                     <button
                       className={cn(
                         "text-sm font-medium transition-all duration-300 relative group flex items-center gap-1",
-                                                activeSection === 'community' || activeSection === 'chat' || activeSection === 'space'
+                                                                        activeSection === 'community' || activeSection === 'chat' || activeSection === 'space' || activeSection === 'rooms'
                           ? "text-pink-400"
                           : "text-gray-400 hover:text-white"
                       )}
                     >
                       Community
                       <ChevronDown className="w-3 h-3" />
-                                            {(activeSection === 'community' || activeSection === 'chat' || activeSection === 'space') && (
+                                                                  {(activeSection === 'community' || activeSection === 'chat' || activeSection === 'space' || activeSection === 'rooms') && (
                         <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full" />
                       )}
                       <div className="absolute -bottom-1 left-0 right-0 h-0.5 bg-gradient-to-r from-pink-400 to-purple-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -64,7 +64,7 @@ interface TrendingTopic {
 export const FuturisticHomepage: React.FC = () => {
   const { setMoodScore } = useMoodTheme();
   const [searchFocused, setSearchFocused] = useState(false);
-      const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space'>('home');
+        const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms'>('home');
   
   // Core mood data
   const [moodScore] = useState<MoodScore>({

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -270,20 +270,7 @@ export const MoorMeterDashboard: React.FC = () => {
                 <TabsTrigger value="Analytics">Analytics</TabsTrigger>
               </TabsList>
 
-              <TabsContent value="HeatMap">
-                <SentimentHeatMap
-                  timeframe={sentimentTimeframe}
-                  onTimeframeChange={setSentimentTimeframe}
-                  viewMode={sentimentViewMode}
-                  onViewModeChange={setSentimentViewMode}
-                  loading={heatmapLoading}
-                  onLoadingChange={setHeatmapLoading}
-                  hoveredCell={hoveredCell}
-                  onHoveredCellChange={setHoveredCell}
-                />
-              </TabsContent>
-
-              <TabsContent value="Watchlist">
+                            <TabsContent value="Watchlist">
                 <WatchlistModule />
               </TabsContent>
 

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -106,7 +106,7 @@ export const MoorMeterDashboard: React.FC = () => {
   const [selectedTimeframe, setSelectedTimeframe] = useState<"1D" | "7D" | "30D">("7D");
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [activeTab, setActiveTab] = useState("Home");
-  const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
+    const [activeToolsSubtab, setActiveToolsSubtab] = useState("Watchlist");
   const [activeCommunitySubtab, setActiveCommunitySubtab] = useState("Chat");
   const [toolsDropdownOpen, setToolsDropdownOpen] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<"General" | "Crypto">("General");

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -67,7 +67,7 @@ import { CryptoChannels } from "./social/CryptoChannels";
 import { OffTopicLounge } from "./social/OffTopicLounge";
 import { MoodScoreHero } from "./builder/MoodScoreHero";
 import { TopStocksModule } from "./builder/TopStocksModule";
-import { SentimentHeatMap } from "./moorMeter/SentimentHeatMap";
+
 import { formatCurrency, cn } from "../lib/utils";
 import { useMoodTheme } from "../contexts/MoodThemeContext";
 import { MoodThemeToggle } from "./ui/mood-theme-toggle";

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -305,11 +305,10 @@ export const MoorMeterDashboard: React.FC = () => {
           <div className="space-y-6">
             <Tabs value={activeCommunitySubtab} onValueChange={setActiveCommunitySubtab}>
                             <TabsList>
-                <TabsTrigger value="Chat">Live Chat</TabsTrigger>
+                                <TabsTrigger value="Chat">Live Chat</TabsTrigger>
                 <TabsTrigger value="Rooms">Rooms</TabsTrigger>
                 <TabsTrigger value="Space">Space</TabsTrigger>
                 <TabsTrigger value="Forum">Forum</TabsTrigger>
-                <TabsTrigger value="Private">Private Rooms</TabsTrigger>
               </TabsList>
 
               <TabsContent value="Chat">

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -68,7 +68,6 @@ import { OffTopicLounge } from "./social/OffTopicLounge";
 import { MoodScoreHero } from "./builder/MoodScoreHero";
 import { TopStocksModule } from "./builder/TopStocksModule";
 import { SentimentHeatMap } from "./moorMeter/SentimentHeatMap";
-import { PrivateRoomsContainer } from "./privateRooms/PrivateRoomsContainer";
 import { formatCurrency, cn } from "../lib/utils";
 import { useMoodTheme } from "../contexts/MoodThemeContext";
 import { MoodThemeToggle } from "./ui/mood-theme-toggle";

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -112,9 +112,7 @@ export const MoorMeterDashboard: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<"General" | "Crypto">("General");
 
   const [sentimentTimeframe, setSentimentTimeframe] = useState<"24h" | "7d" | "30d">("24h");
-  const [sentimentViewMode, setSentimentViewMode] = useState<"absolute" | "net">("absolute");
-  const [heatmapLoading, setHeatmapLoading] = useState(false);
-  const [hoveredCell, setHoveredCell] = useState<{ ticker: string; time: string; data: any } | null>(null);
+  
 
   const { data: stockSentiment, loading: stockLoading } = useStockSentiment();
   const { articles: newsArticles, loading: newsLoading } = useCombinedBusinessNews();

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -265,8 +265,7 @@ export const MoorMeterDashboard: React.FC = () => {
         return (
           <div className="space-y-6">
             <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
-              <TabsList>
-                <TabsTrigger value="HeatMap">Heat Map</TabsTrigger>
+                            <TabsList>
                 <TabsTrigger value="Watchlist">Watchlist</TabsTrigger>
                 <TabsTrigger value="Analytics">Analytics</TabsTrigger>
               </TabsList>

--- a/client/src/components/MoorMeterDashboard.tsx
+++ b/client/src/components/MoorMeterDashboard.tsx
@@ -349,12 +349,8 @@ export const MoorMeterDashboard: React.FC = () => {
                 </div>
               </TabsContent>
 
-              <TabsContent value="Forum">
+                            <TabsContent value="Forum">
                 <CommunityForum />
-              </TabsContent>
-
-              <TabsContent value="Private">
-                <PrivateRoomsContainer />
               </TabsContent>
             </Tabs>
           </div>

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -422,21 +422,7 @@ export const Navigation = ({
           {isMenuOpen && (
             <div className="md:hidden py-4 border-t">
               <div className="flex flex-col space-y-2">
-                {/* MoorMeter Dashboard */}
-                <Button
-                  variant={activeSection === "moorMeter" ? "default" : "ghost"}
-                  onClick={() => {
-                    onSectionChange("moorMeter");
-                    setIsMenuOpen(false);
-                  }}
-                  className="justify-start gap-2"
-                >
-                  <Brain className="h-4 w-4" />
-                  MoorMeter
-                  <Badge variant="secondary" className="ml-auto text-xs">
-                    NEW
-                  </Badge>
-                </Button>
+                
 
                 {/* Data Section */}
                 <div className="text-sm font-medium text-muted-foreground px-3 py-1">

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -258,24 +258,7 @@ export const Navigation = ({
                 </DropdownMenuContent>
               </DropdownMenu>
 
-                            {/* Tool Dropdown */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" className="flex items-center gap-1">
-                    Tool
-                    <ChevronDown className="h-3 w-3" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start">
-                  <DropdownMenuItem
-                    onClick={() => onSectionChange("market")}
-                    className="flex items-center gap-2"
-                  >
-                    <BarChart3 className="h-4 w-4" />
-                    Market
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                            
             </div>
 
                         {/* User Section */}

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -170,18 +170,7 @@ export const Navigation = ({
                 </Badge>
               </Button>
 
-              {/* MoorMeter Dashboard */}
-              <Button
-                variant={activeSection === "moorMeter" ? "default" : "ghost"}
-                onClick={() => onSectionChange("moorMeter")}
-                className="flex items-center gap-2"
-              >
-                <Brain className="h-4 w-4" />
-                MoorMeter
-                <Badge variant="secondary" className="text-xs">
-                  NEW
-                </Badge>
-              </Button>
+              
 
               {/* Data Dropdown */}
               <DropdownMenu>

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -120,11 +120,11 @@ export const Navigation = ({
     setAuthModalOpen(true);
   };
 
-  const handleLogout = () => {
+    const handleLogout = () => {
     logout();
-    // Redirect to moorMeter if currently on protected pages
+    // Redirect to home if currently on protected pages
     if (activeSection === "profile") {
-      onSectionChange("moorMeter");
+      onSectionChange("home");
     }
   };
 

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -447,21 +447,7 @@ export const Navigation = ({
                   );
                 })}
 
-                                {/* Tool Section */}
-                <div className="text-sm font-medium text-muted-foreground px-3 py-1">
-                  Tool
-                </div>
-                <Button
-                  variant={activeSection === "market" ? "default" : "ghost"}
-                  onClick={() => {
-                    onSectionChange("market");
-                    setIsMenuOpen(false);
-                  }}
-                  className="justify-start gap-2 ml-4"
-                >
-                  <BarChart3 className="h-4 w-4" />
-                  Market
-                </Button>
+                                
 
                 {/* Mobile Auth Section */}
                 <div className="pt-4 border-t">

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -464,32 +464,21 @@ export const Navigation = ({
                   );
                 })}
 
-                {/* Tools Section */}
+                                {/* Tool Section */}
                 <div className="text-sm font-medium text-muted-foreground px-3 py-1">
-                  Tools
+                  Tool
                 </div>
-                {navigationGroups.tools.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Button
-                      key={item.id}
-                      variant={activeSection === item.id ? "default" : "ghost"}
-                      onClick={() => {
-                        onSectionChange(item.id);
-                        setIsMenuOpen(false);
-                      }}
-                      className="justify-start gap-2 ml-4"
-                    >
-                      <Icon className="h-4 w-4" />
-                      {item.label}
-                      {item.badge && (
-                        <Badge variant="secondary" className="ml-auto text-xs">
-                          {item.badge}
-                        </Badge>
-                      )}
-                    </Button>
-                  );
-                })}
+                <Button
+                  variant={activeSection === "market" ? "default" : "ghost"}
+                  onClick={() => {
+                    onSectionChange("market");
+                    setIsMenuOpen(false);
+                  }}
+                  className="justify-start gap-2 ml-4"
+                >
+                  <BarChart3 className="h-4 w-4" />
+                  Market
+                </Button>
 
                 {/* Mobile Auth Section */}
                 <div className="pt-4 border-t">

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -258,36 +258,22 @@ export const Navigation = ({
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              {/* Tools Dropdown */}
+                            {/* Tool Dropdown */}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" className="flex items-center gap-1">
-                    Tools
+                    Tool
                     <ChevronDown className="h-3 w-3" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start">
-                  {navigationGroups.tools.map((item) => {
-                    const Icon = item.icon;
-                    return (
-                      <DropdownMenuItem
-                        key={item.id}
-                        onClick={() => onSectionChange(item.id)}
-                        className="flex items-center gap-2"
-                      >
-                        <Icon className="h-4 w-4" />
-                        {item.label}
-                        {item.badge && (
-                          <Badge
-                            variant="secondary"
-                            className="ml-auto text-xs"
-                          >
-                            {item.badge}
-                          </Badge>
-                        )}
-                      </DropdownMenuItem>
-                    );
-                  })}
+                  <DropdownMenuItem
+                    onClick={() => onSectionChange("market")}
+                    className="flex items-center gap-2"
+                  >
+                    <BarChart3 className="h-4 w-4" />
+                    Market
+                  </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>

--- a/client/src/components/temp_tool_section.txt
+++ b/client/src/components/temp_tool_section.txt
@@ -1,0 +1,188 @@
+{/* Tool Dropdown Menu */}
+            <div className="max-w-7xl mx-auto">
+              <div className="mb-6">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button 
+                      variant="outline" 
+                      className="w-64 justify-between bg-black/40 backdrop-blur-xl border-purple-500/20 text-white hover:bg-purple-500/20"
+                    >
+                      {activeToolSubtab === "Market" && "📈 Market"}
+                      {activeToolSubtab === "Analysis" && "📊 Analysis"}
+                      {activeToolSubtab === "Scanner" && "🔍 Scanner"}
+                      {activeToolSubtab === "Alerts" && "��� Alerts"}
+                      <ChevronDown className="h-4 w-4 opacity-50" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent 
+                    className="w-64 bg-black/90 backdrop-blur-xl border-purple-500/30 text-white"
+                    align="start"
+                  >
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Market")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      📈 Market
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Analysis")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      📊 Analysis
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Scanner")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      🔍 Scanner
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setActiveToolSubtab("Alerts")}
+                      className="hover:bg-purple-500/20 focus:bg-purple-500/20 cursor-pointer"
+                    >
+                      🔔 Alerts
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              {/* Content based on dropdown selection */}
+              {activeToolSubtab === "Market" && (
+                <div className="space-y-6">
+                  <div className="mb-6">
+                    <h2 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
+                      📊 Advanced Market Analysis Tools
+                    </h2>
+                    <p className="text-gray-400">
+                      Professional tools for market analysis and visualization
+                    </p>
+                  </div>
+
+                  {/* Tools Sub-subtabs */}
+                  <Tabs value={activeToolsSubtab} onValueChange={setActiveToolsSubtab}>
+                    <TabsList className="grid w-full grid-cols-3 bg-black/20 backdrop-blur-xl border border-gray-700/50">
+                      <TabsTrigger
+                        value="HeatMap"
+                        className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+                      >
+                        📊 Heat Map
+                      </TabsTrigger>
+                      <TabsTrigger
+                        value="Analytics"
+                        className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+                      >
+                        📈 Analytics
+                      </TabsTrigger>
+                      <TabsTrigger
+                        value="Scanner"
+                        className="data-[state=active]:bg-gray-700/50 data-[state=active]:text-white text-gray-400"
+                      >
+                        🔍 Scanner
+                      </TabsTrigger>
+                    </TabsList>
+
+                    <TabsContent value="HeatMap" className="mt-6">
+                      <div className="space-y-6">
+                        <div className="mb-6">
+                          <h3 className="text-xl font-bold text-white mb-2 flex items-center gap-2">
+                            📊 Market Heat Map
+                          </h3>
+                          <p className="text-gray-400">
+                            Visualize real-time sentiment movements across different stocks and timeframes
+                          </p>
+                        </div>
+
+                        <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-6">
+                          <SentimentHeatMap />
+                        </div>
+                      </div>
+                    </TabsContent>
+
+                    <TabsContent value="Analytics" className="mt-6">
+                      <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                        <div className="text-center space-y-4">
+                          <div className="text-6xl mb-4">📈</div>
+                          <h3 className="text-2xl font-bold text-white mb-2">Advanced Analytics</h3>
+                          <p className="text-gray-400 mb-4">
+                            Comprehensive market analysis and trend insights coming soon.
+                          </p>
+                          <div className="flex flex-wrap gap-2 justify-center">
+                            <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Technical Indicators</Badge>
+                            <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Trend Analysis</Badge>
+                            <Badge className="bg-purple-500/20 text-purple-300 border-purple-500/30">Volume Patterns</Badge>
+                          </div>
+                        </div>
+                      </div>
+                    </TabsContent>
+
+                    <TabsContent value="Scanner" className="mt-6">
+                      <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                        <div className="text-center space-y-4">
+                          <div className="text-6xl mb-4">🔍</div>
+                          <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
+                          <p className="text-gray-400 mb-4">
+                            Real-time stock and crypto scanner with custom filters and alerts.
+                          </p>
+                          <div className="flex flex-wrap gap-2 justify-center">
+                            <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Price Alerts</Badge>
+                            <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Volume Spikes</Badge>
+                            <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/30">Breakout Detection</Badge>
+                          </div>
+                        </div>
+                      </div>
+                    </TabsContent>
+                  </Tabs>
+                </div>
+              )}
+
+              {activeToolSubtab === "Analysis" && (
+                <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                  <div className="text-center space-y-4">
+                    <div className="text-6xl mb-4">📊</div>
+                    <h3 className="text-2xl font-bold text-white mb-2">Advanced Analysis Suite</h3>
+                    <p className="text-gray-400 mb-4">
+                      Comprehensive technical and fundamental analysis tools.
+                    </p>
+                    <div className="flex flex-wrap gap-2 justify-center">
+                      <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Technical Analysis</Badge>
+                      <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Chart Patterns</Badge>
+                      <Badge className="bg-orange-500/20 text-orange-300 border-orange-500/30">Indicators</Badge>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {activeToolSubtab === "Scanner" && (
+                <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                  <div className="text-center space-y-4">
+                    <div className="text-6xl mb-4">🔍</div>
+                    <h3 className="text-2xl font-bold text-white mb-2">Market Scanner</h3>
+                    <p className="text-gray-400 mb-4">
+                      Real-time stock and crypto scanner with custom filters.
+                    </p>
+                    <div className="flex flex-wrap gap-2 justify-center">
+                      <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Price Alerts</Badge>
+                      <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Volume Spikes</Badge>
+                      <Badge className="bg-yellow-500/20 text-yellow-300 border-yellow-500/30">Breakouts</Badge>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {activeToolSubtab === "Alerts" && (
+                <div className="bg-black/40 backdrop-blur-xl rounded-2xl border border-purple-500/20 p-8">
+                  <div className="text-center space-y-4">
+                    <div className="text-6xl mb-4">🔔</div>
+                    <h3 className="text-2xl font-bold text-white mb-2">Smart Alerts</h3>
+                    <p className="text-gray-400 mb-4">
+                      Intelligent alerts and notifications for trading opportunities.
+                    </p>
+                    <div className="flex flex-wrap gap-2 justify-center">
+                      <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Price Alerts</Badge>
+                      <Badge className="bg-red-500/20 text-red-300 border-red-500/30">News Alerts</Badge>
+                      <Badge className="bg-red-500/20 text-red-300 border-red-500/30">Technical Signals</Badge>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>


### PR DESCRIPTION
This commit adds significant navigation and content enhancements to the FuturisticHomepage component:

**New Navigation:**
- Added "Tool" dropdown menu with Market option
- Expanded Community dropdown with Space and Rooms options
- Added new state variables for managing active sections and subtabs

**New Components:**
- Imported Tabs, TabsContent, TabsList, TabsTrigger from ui/tabs
- Imported SpaceSwitcherWidget, PrivateRoomsContainer, and SentimentHeatMap components

**Content Sections:**
- Added Space section rendering SpaceSwitcherWidget
- Added Rooms section rendering PrivateRoomsContainer  
- Added comprehensive Tool/Market section with tabbed interface
- Implemented nested tabs for Market tools (HeatMap, Analytics, Scanner)
- Added placeholder content for Analysis, Scanner, and Alerts subsections

**State Management:**
- Extended activeSection type to include 'space', 'rooms', 'tool', 'market'
- Added activeToolSubtab, activeMarketSubtab, and activeToolsSubtab state variables
- Updated conditional rendering logic for new sections

**UI Improvements:**
- Enhanced dropdown menu styling and interactions
- Added proper active state indicators for new navigation items
- Implemented consistent styling across all new sections

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/4af1d2e8911040e5a8e54993bc5e84ef/zen-lab)

👀 [Preview Link](https://4af1d2e8911040e5a8e54993bc5e84ef-zen-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4af1d2e8911040e5a8e54993bc5e84ef</projectId>-->
<!--<branchName>zen-lab</branchName>-->