### PR TITLE
Add voting modal for sentiment polls and trade entry form

### DIFF
--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -5,8 +5,9 @@ import { Badge } from './ui/badge';
 import { Input } from './ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from './ui/dialog';
 import { useMoodTheme } from '../contexts/MoodThemeContext';
-import { Users, BarChart3, TrendingUp, Vote, Search, RefreshCw, Check, Trophy, Award, Star } from 'lucide-react';
+import { Users, BarChart3, TrendingUp, Vote, Search, RefreshCw, Check, Trophy, Award, Star, X } from 'lucide-react';
 import { cn } from '../lib/utils';
 
 interface StockPoll {

--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -512,6 +512,7 @@ export default function CommunitySentimentPolls() {
                         <Button
                           variant="default"
                           size="sm"
+                          onClick={() => handleVoteClick(poll)}
                           className="bg-purple-600 hover:bg-purple-700 text-white text-xs"
                         >
                           Vote Now

--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -787,6 +787,7 @@ export default function CommunitySentimentPolls() {
                       <Button
                         variant="default"
                         size="sm"
+                        onClick={() => handleVoteClick(poll)}
                         className="bg-purple-600 hover:bg-purple-700 text-white text-xs"
                       >
                         Change Vote

--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -566,7 +566,7 @@ export default function CommunitySentimentPolls() {
                     accuracy: 81.7,
                     votes: 312,
                     streak: 15,
-                    badges: ['👤', '📊']
+                    badges: ['👤', '���']
                   },
                   {
                     rank: 4,
@@ -800,6 +800,77 @@ export default function CommunitySentimentPolls() {
           </div>
         </TabsContent>
       </Tabs>
+
+      {/* Voting Modal */}
+      <Dialog open={voteModalOpen} onOpenChange={setVoteModalOpen}>
+        <DialogContent className={cn(
+          "max-w-md",
+          themeMode === 'light'
+            ? 'bg-white border-gray-200'
+            : 'bg-gray-900 border-purple-500/20'
+        )}>
+          <DialogHeader>
+            <DialogTitle className={cn(
+              "text-xl font-bold text-center",
+              themeMode === 'light' ? 'text-[#1E1E1E]' : 'text-white'
+            )}>
+              Vote on {selectedPoll?.ticker}
+            </DialogTitle>
+            <DialogDescription className={cn(
+              "text-center mt-2",
+              themeMode === 'light' ? 'text-[#666]' : 'text-gray-300'
+            )}>
+              Share your sentiment prediction for the next 24 hours.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3 mt-6">
+            {/* Bullish Button */}
+            <Button
+              onClick={() => handleVoteSubmit('bullish')}
+              className="w-full h-14 bg-green-600 hover:bg-green-700 text-white font-semibold text-lg rounded-lg transition-all duration-200 hover:scale-105"
+            >
+              <div className="flex items-center gap-3">
+                <TrendingUp className="w-6 h-6" />
+                <span>Bullish</span>
+              </div>
+            </Button>
+
+            {/* Holding Button */}
+            <Button
+              onClick={() => handleVoteSubmit('holding')}
+              className="w-full h-14 bg-yellow-600 hover:bg-yellow-700 text-white font-semibold text-lg rounded-lg transition-all duration-200 hover:scale-105"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-6 h-6 bg-yellow-400 rounded-sm flex items-center justify-center">
+                  <span className="text-yellow-800 font-bold text-sm">—</span>
+                </div>
+                <span>Holding</span>
+              </div>
+            </Button>
+
+            {/* Bearish Button */}
+            <Button
+              onClick={() => handleVoteSubmit('bearish')}
+              className="w-full h-14 bg-red-600 hover:bg-red-700 text-white font-semibold text-lg rounded-lg transition-all duration-200 hover:scale-105"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-6 h-6 bg-red-500 rounded-sm flex items-center justify-center rotate-180">
+                  <TrendingUp className="w-4 h-4" />
+                </div>
+                <span>Bearish</span>
+              </div>
+            </Button>
+          </div>
+
+          <div className={cn(
+            "text-center text-sm mt-4",
+            themeMode === 'light' ? 'text-[#666]' : 'text-gray-400'
+          )}>
+            You can change your vote within 24 hours
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -28,6 +28,8 @@ export default function CommunitySentimentPolls() {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState('most-votes');
   const [activeTab, setActiveTab] = useState('live');
+  const [voteModalOpen, setVoteModalOpen] = useState(false);
+  const [selectedPoll, setSelectedPoll] = useState<StockPoll | null>(null);
 
   const [polls] = useState<StockPoll[]>([
     {

--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -108,6 +108,29 @@ export default function CommunitySentimentPolls() {
     }
   };
 
+  const handleVoteClick = (poll: StockPoll) => {
+    setSelectedPoll(poll);
+    setVoteModalOpen(true);
+  };
+
+  const handleVoteSubmit = (voteType: 'bullish' | 'holding' | 'bearish') => {
+    if (!selectedPoll) return;
+
+    setPolls(prev => prev.map(poll => {
+      if (poll.id === selectedPoll.id) {
+        return {
+          ...poll,
+          userVote: voteType,
+          votes: poll.votes + (poll.userVote ? 0 : 1)
+        };
+      }
+      return poll;
+    }));
+
+    setVoteModalOpen(false);
+    setSelectedPoll(null);
+  };
+
   const VoteButton = ({ poll, voteType }: { poll: StockPoll, voteType: 'bullish' | 'holding' | 'bearish' }) => {
     const isUserVote = poll.userVote === voteType;
     const hasVoted = poll.userVote !== null;

--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -31,7 +31,7 @@ export default function CommunitySentimentPolls() {
   const [voteModalOpen, setVoteModalOpen] = useState(false);
   const [selectedPoll, setSelectedPoll] = useState<StockPoll | null>(null);
 
-  const [polls] = useState<StockPoll[]>([
+  const [polls, setPolls] = useState<StockPoll[]>([
     {
       id: '1',
       ticker: 'BTC',

--- a/client/src/components/CommunitySentimentPolls.tsx
+++ b/client/src/components/CommunitySentimentPolls.tsx
@@ -134,7 +134,7 @@ export default function CommunitySentimentPolls() {
   const VoteButton = ({ poll, voteType }: { poll: StockPoll, voteType: 'bullish' | 'holding' | 'bearish' }) => {
     const isUserVote = poll.userVote === voteType;
     const hasVoted = poll.userVote !== null;
-    
+
     if (hasVoted && !isUserVote) {
       return null; // Don't show vote buttons for other options if user already voted
     }
@@ -143,9 +143,10 @@ export default function CommunitySentimentPolls() {
       <Button
         variant={isUserVote ? "default" : "outline"}
         size="sm"
+        onClick={() => handleVoteClick(poll)}
         className={cn(
           "text-xs",
-          isUserVote 
+          isUserVote
             ? "bg-purple-600 hover:bg-purple-700 text-white"
             : themeMode === 'light'
               ? 'border-gray-300 text-gray-600 hover:bg-gray-100'

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -28,8 +28,18 @@ interface Trade {
 
 export default function TradeJournalClassic() {
   const { themeMode } = useMoodTheme();
-  
-  const [trades] = useState<Trade[]>([
+  const [addTradeModalOpen, setAddTradeModalOpen] = useState(false);
+  const [formData, setFormData] = useState({
+    ticker: '',
+    positionType: 'Buy',
+    entryPrice: '',
+    exitPrice: '',
+    quantity: '',
+    emotion: '',
+    notes: ''
+  });
+
+  const [trades, setTrades] = useState<Trade[]>([
     {
       id: '1',
       ticker: 'AAPL',

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -3,8 +3,11 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from './ui/dialog';
+import { Input } from './ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { useMoodTheme } from '../contexts/MoodThemeContext';
-import { Plus, BarChart3, Activity, Download, AlertTriangle, CheckCircle } from 'lucide-react';
+import { Plus, BarChart3, Activity, Download, AlertTriangle, CheckCircle, X, TrendingUp } from 'lucide-react';
 import { cn } from '../lib/utils';
 
 interface Trade {

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -20,6 +20,7 @@ interface Trade {
   quantity: number;
   pnl?: number;
   sentiment: number;
+  emotion: string;
   notes: string;
   entryDate: string;
   exitDate?: string;

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -50,6 +50,7 @@ export default function TradeJournalClassic() {
       quantity: 100,
       pnl: 680.00,
       sentiment: 72,
+      emotion: 'Confident',
       notes: 'Strong earnings report expected, technical breakout confirmed',
       entryDate: '2024-01-15',
       exitDate: '2024-01-22'
@@ -62,6 +63,7 @@ export default function TradeJournalClassic() {
       entryPrice: 245.80,
       quantity: 50,
       sentiment: 45,
+      emotion: 'Fearful',
       notes: 'Bought the dip but market sentiment very negative',
       entryDate: '2024-01-20'
     },
@@ -75,6 +77,7 @@ export default function TradeJournalClassic() {
       quantity: 25,
       pnl: -537.50,
       sentiment: 85,
+      emotion: 'Greedy',
       notes: 'FOMO on AI hype, ignored technical signals',
       entryDate: '2024-01-10',
       exitDate: '2024-01-18'

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -93,10 +93,73 @@ export default function TradeJournalClassic() {
   const getTickerLogo = (ticker: string) => {
     const logos: Record<string, string> = {
       'AAPL': '🍎',
-      'TSLA': '🚗', 
+      'TSLA': '🚗',
       'NVDA': '🔥'
     };
     return logos[ticker] || '📈';
+  };
+
+  const emotionOptions = [
+    { value: 'confident', label: 'Confident', icon: '🧠' },
+    { value: 'greedy', label: 'Greedy', icon: '🐂' },
+    { value: 'fearful', label: 'Fearful', icon: '😰' },
+    { value: 'strategic', label: 'Strategic', icon: '🎯' },
+    { value: 'impulsive', label: 'Impulsive', icon: '⚡' },
+    { value: 'uncertain', label: 'Uncertain', icon: '😕' },
+    { value: 'calm', label: 'Calm', icon: '😎' },
+    { value: 'euphoric', label: 'Euphoric', icon: '🔥' }
+  ];
+
+  const handleAddTradeClick = () => {
+    setAddTradeModalOpen(true);
+  };
+
+  const handleFormSubmit = () => {
+    if (!formData.ticker || !formData.entryPrice || !formData.quantity || !formData.emotion) {
+      return; // Validation - require these fields
+    }
+
+    const newTrade: Trade = {
+      id: Date.now().toString(),
+      ticker: formData.ticker.toUpperCase(),
+      action: formData.positionType.toUpperCase() as 'BUY' | 'SELL',
+      status: 'OPEN',
+      entryPrice: parseFloat(formData.entryPrice),
+      exitPrice: formData.exitPrice ? parseFloat(formData.exitPrice) : undefined,
+      quantity: parseInt(formData.quantity),
+      sentiment: 65, // Default market sentiment
+      emotion: formData.emotion,
+      notes: formData.notes,
+      entryDate: new Date().toISOString().split('T')[0]
+    };
+
+    setTrades(prev => [newTrade, ...prev]);
+
+    // Reset form
+    setFormData({
+      ticker: '',
+      positionType: 'Buy',
+      entryPrice: '',
+      exitPrice: '',
+      quantity: '',
+      emotion: '',
+      notes: ''
+    });
+
+    setAddTradeModalOpen(false);
+  };
+
+  const handleCancel = () => {
+    setFormData({
+      ticker: '',
+      positionType: 'Buy',
+      entryPrice: '',
+      exitPrice: '',
+      quantity: '',
+      emotion: '',
+      notes: ''
+    });
+    setAddTradeModalOpen(false);
   };
 
   return (

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -286,12 +286,15 @@ export default function TradeJournalClassic() {
 
         {/* Add New Trade Button */}
         <div className="flex justify-center">
-          <Button className={cn(
-            "px-6 py-3 rounded-xl font-semibold flex items-center gap-2",
-            themeMode === 'light'
-              ? 'bg-[#3F51B5] hover:bg-[#303F9F] text-white'
-              : 'bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white'
-          )}>
+          <Button
+            onClick={handleAddTradeClick}
+            className={cn(
+              "px-6 py-3 rounded-xl font-semibold flex items-center gap-2",
+              themeMode === 'light'
+                ? 'bg-[#3F51B5] hover:bg-[#303F9F] text-white'
+                : 'bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white'
+            )}
+          >
             <Plus className="w-5 h-5" />
             Add New Trade
           </Button>

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -5,6 +5,7 @@ import { Badge } from './ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from './ui/dialog';
 import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { useMoodTheme } from '../contexts/MoodThemeContext';
 import { Plus, BarChart3, Activity, Download, AlertTriangle, CheckCircle, X, TrendingUp } from 'lucide-react';

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -685,6 +685,237 @@ export default function TradeJournalClassic() {
           </Card>
         </TabsContent>
       </Tabs>
+
+      {/* Add New Trade Modal */}
+      <Dialog open={addTradeModalOpen} onOpenChange={setAddTradeModalOpen}>
+        <DialogContent className={cn(
+          "max-w-2xl max-h-[90vh] overflow-y-auto",
+          themeMode === 'light'
+            ? 'bg-white border-gray-200'
+            : 'bg-gray-900 border-purple-500/20'
+        )}>
+          <DialogHeader>
+            <DialogTitle className={cn(
+              "text-xl font-bold",
+              themeMode === 'light' ? 'text-[#1E1E1E]' : 'text-white'
+            )}>
+              Log New Trade
+            </DialogTitle>
+            <DialogDescription className={cn(
+              "mt-2",
+              themeMode === 'light' ? 'text-[#666]' : 'text-gray-300'
+            )}>
+              Record your trade details and emotional state for better analysis.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-6 mt-6">
+            {/* First Row: Ticker and Position Type */}
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className={cn(
+                  "block text-sm font-medium mb-2",
+                  themeMode === 'light' ? 'text-[#333]' : 'text-gray-300'
+                )}>
+                  Ticker
+                </label>
+                <Input
+                  placeholder="e.g., AAPL"
+                  value={formData.ticker}
+                  onChange={(e) => setFormData(prev => ({ ...prev, ticker: e.target.value }))}
+                  className={cn(
+                    themeMode === 'light'
+                      ? 'bg-white border-gray-300'
+                      : 'bg-gray-800 border-gray-600 text-white'
+                  )}
+                />
+              </div>
+              <div>
+                <label className={cn(
+                  "block text-sm font-medium mb-2",
+                  themeMode === 'light' ? 'text-[#333]' : 'text-gray-300'
+                )}>
+                  Position Type
+                </label>
+                <Select value={formData.positionType} onValueChange={(value) => setFormData(prev => ({ ...prev, positionType: value }))}>
+                  <SelectTrigger className={cn(
+                    themeMode === 'light'
+                      ? 'bg-white border-gray-300'
+                      : 'bg-gray-800 border-gray-600 text-white'
+                  )}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Buy">Buy</SelectItem>
+                    <SelectItem value="Sell">Sell</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {/* Second Row: Entry Price, Exit Price, Quantity */}
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className={cn(
+                  "block text-sm font-medium mb-2",
+                  themeMode === 'light' ? 'text-[#333]' : 'text-gray-300'
+                )}>
+                  Entry Price
+                </label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={formData.entryPrice}
+                  onChange={(e) => setFormData(prev => ({ ...prev, entryPrice: e.target.value }))}
+                  className={cn(
+                    themeMode === 'light'
+                      ? 'bg-white border-gray-300'
+                      : 'bg-gray-800 border-gray-600 text-white'
+                  )}
+                />
+              </div>
+              <div>
+                <label className={cn(
+                  "block text-sm font-medium mb-2",
+                  themeMode === 'light' ? 'text-[#333]' : 'text-gray-300'
+                )}>
+                  Exit Price (Optional)
+                </label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={formData.exitPrice}
+                  onChange={(e) => setFormData(prev => ({ ...prev, exitPrice: e.target.value }))}
+                  className={cn(
+                    themeMode === 'light'
+                      ? 'bg-white border-gray-300'
+                      : 'bg-gray-800 border-gray-600 text-white'
+                  )}
+                />
+              </div>
+              <div>
+                <label className={cn(
+                  "block text-sm font-medium mb-2",
+                  themeMode === 'light' ? 'text-[#333]' : 'text-gray-300'
+                )}>
+                  Quantity
+                </label>
+                <Input
+                  type="number"
+                  placeholder="100"
+                  value={formData.quantity}
+                  onChange={(e) => setFormData(prev => ({ ...prev, quantity: e.target.value }))}
+                  className={cn(
+                    themeMode === 'light'
+                      ? 'bg-white border-gray-300'
+                      : 'bg-gray-800 border-gray-600 text-white'
+                  )}
+                />
+              </div>
+            </div>
+
+            {/* Market Sentiment Indicator */}
+            <div className={cn(
+              "p-4 rounded-lg border",
+              themeMode === 'light'
+                ? 'bg-blue-50 border-blue-200'
+                : 'bg-blue-900/20 border-blue-500/30'
+            )}>
+              <div className="flex items-center gap-2 mb-2">
+                <TrendingUp className="w-5 h-5 text-blue-400" />
+                <span className={cn(
+                  "font-medium",
+                  themeMode === 'light' ? 'text-blue-800' : 'text-blue-300'
+                )}>
+                  Current Market Sentiment: 65/100
+                </span>
+              </div>
+              <div className="w-full bg-gray-700 rounded-full h-3">
+                <div
+                  className="bg-gradient-to-r from-blue-500 to-purple-500 h-3 rounded-full transition-all duration-300"
+                  style={{ width: '65%' }}
+                />
+              </div>
+            </div>
+
+            {/* Emotion Selection */}
+            <div>
+              <label className={cn(
+                "block text-sm font-medium mb-4",
+                themeMode === 'light' ? 'text-[#333]' : 'text-gray-300'
+              )}>
+                How are you feeling about this trade?
+              </label>
+              <div className="grid grid-cols-4 gap-3">
+                {emotionOptions.map((emotion) => (
+                  <Button
+                    key={emotion.value}
+                    variant={formData.emotion === emotion.value ? "default" : "outline"}
+                    onClick={() => setFormData(prev => ({ ...prev, emotion: emotion.value }))}
+                    className={cn(
+                      "h-20 flex flex-col items-center gap-2 text-sm transition-all duration-200",
+                      formData.emotion === emotion.value
+                        ? "bg-purple-600 hover:bg-purple-700 text-white border-purple-500"
+                        : themeMode === 'light'
+                          ? 'border-gray-300 text-gray-600 hover:bg-gray-100'
+                          : 'border-gray-600 text-gray-300 hover:bg-gray-800'
+                    )}
+                  >
+                    <span className="text-xl">{emotion.icon}</span>
+                    <span>{emotion.label}</span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            {/* Notes */}
+            <div>
+              <label className={cn(
+                "block text-sm font-medium mb-2",
+                themeMode === 'light' ? 'text-[#333]' : 'text-gray-300'
+              )}>
+                Notes (Optional)
+              </label>
+              <textarea
+                rows={4}
+                placeholder="Why did you make this trade? What was your reasoning?"
+                value={formData.notes}
+                onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
+                className={cn(
+                  "w-full px-3 py-2 border rounded-md resize-none",
+                  themeMode === 'light'
+                    ? 'bg-white border-gray-300 text-gray-900 placeholder-gray-500'
+                    : 'bg-gray-800 border-gray-600 text-white placeholder-gray-400'
+                )}
+              />
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex gap-3 pt-4">
+              <Button
+                onClick={handleFormSubmit}
+                className="flex-1 bg-purple-600 hover:bg-purple-700 text-white font-semibold py-3"
+              >
+                Add Trade
+              </Button>
+              <Button
+                onClick={handleCancel}
+                variant="outline"
+                className={cn(
+                  "px-6 py-3",
+                  themeMode === 'light'
+                    ? 'border-gray-300 text-gray-600 hover:bg-gray-100'
+                    : 'border-gray-600 text-gray-300 hover:bg-gray-800'
+                )}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -879,16 +879,16 @@ export default function TradeJournalClassic() {
               )}>
                 Notes (Optional)
               </label>
-              <textarea
+              <Textarea
                 rows={4}
                 placeholder="Why did you make this trade? What was your reasoning?"
                 value={formData.notes}
                 onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
                 className={cn(
-                  "w-full px-3 py-2 border rounded-md resize-none",
+                  "resize-none",
                   themeMode === 'light'
-                    ? 'bg-white border-gray-300 text-gray-900 placeholder-gray-500'
-                    : 'bg-gray-800 border-gray-600 text-white placeholder-gray-400'
+                    ? 'bg-white border-gray-300'
+                    : 'bg-gray-800 border-gray-600 text-white'
                 )}
               />
             </div>

--- a/client/src/components/TradeJournalClassic.tsx
+++ b/client/src/components/TradeJournalClassic.tsx
@@ -413,7 +413,7 @@ export default function TradeJournalClassic() {
                           "text-sm",
                           themeMode === 'light' ? 'text-[#666]' : 'text-gray-400'
                         )}>
-                          Confident • {trade.entryDate}
+                          {trade.emotion} • {trade.entryDate}
                           {trade.exitDate && ` → ${trade.exitDate}`}
                         </div>
                       </div>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements two key modal interfaces to improve user interaction:

1. **Sentiment Poll Voting**: Users requested a popup modal when clicking "Vote Now" buttons on sentiment polls to allow them to cast their votes (bullish, holding, bearish)
2. **Trade Journal Entry**: Users requested a popup modal when clicking "Add new trade" button to enable logging new trades with detailed information

## Code changes

### Sentiment Poll Modal (`CommunitySentimentPolls.tsx`)
- Added `Dialog` component import and voting modal state management
- Implemented `handleVoteClick()` and `handleVoteSubmit()` functions for vote processing
- Created voting modal with three sentiment options (Bullish, Holding, Bearish)
- Added vote state tracking and poll updates when users submit votes
- Connected "Vote Now" and "Change Vote" buttons to open the modal

### Trade Journal Modal (`TradeJournalClassic.tsx`)
- Added comprehensive trade entry form with fields for ticker, position type, prices, quantity
- Implemented emotion tracking with visual emotion selector (4 emotion options)
- Added market sentiment indicator display
- Created form state management and submission handling
- Connected "Add new trade" button to open the modal
- Added form validation and cancel functionality

Both modals include proper theming support and responsive design consistent with the existing UI.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/56f4348cf8de47ef89a601d8ef438566/quantum-lab)

👀 [Preview Link](https://56f4348cf8de47ef89a601d8ef438566-quantum-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>56f4348cf8de47ef89a601d8ef438566</projectId>-->
<!--<branchName>quantum-lab</branchName>-->