### PR TITLE
Restore finance hub to original FuturisticHomepage

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -210,7 +210,7 @@ const AppContent = () => {
 
       // Finance Section Routes
       case "finance":
-        return <BuilderFinanceDemo />;
+        return <FuturisticHomepage onNavigate={setActiveSection} initialSection="finance" />;
       case "watchlist":
         return <Watchlist />;
       case "market":

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -114,6 +114,13 @@ export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNaviga
   const [financeSearchQuery, setFinanceSearchQuery] = useState("");
   const [selectedTimeframe, setSelectedTimeframe] = useState<"1D" | "7D" | "30D">("7D");
 
+  // Handle initialSection prop
+  useEffect(() => {
+    if (initialSection) {
+      setActiveSection(initialSection as any);
+    }
+  }, [initialSection]);
+
   // Core mood data
   const [moodScore] = useState<MoodScore>({
     overall: 72,

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -105,7 +105,7 @@ interface FuturisticHomepageProps {
 
 export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNavigate, initialSection }) => {
   const { setMoodScore, themeMode, cardBackground, borderColor } = useMoodTheme();
-  const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool' | 'market' | 'crypto' | 'charts' | 'trending' | 'earnings' | 'finance' | 'screener' | 'trade-journal' | 'sentiment-polls'>('home');
+  const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool' | 'market' | 'crypto' | 'charts' | 'trending' | 'earnings' | 'finance' | 'screener' | 'trade-journal' | 'sentiment-polls'>(initialSection as any || 'home');
   const [activeToolSubtab, setActiveToolSubtab] = useState("Market");
   const [activeMarketSubtab, setActiveMarketSubtab] = useState("Tools");
   const [activeToolsSubtab, setActiveToolsSubtab] = useState("HeatMap");
@@ -879,7 +879,7 @@ export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNaviga
                       ����� Top Bullish
                     </TabsTrigger>
                     <TabsTrigger value="bearish" className="data-[state=active]:bg-red-600/30 data-[state=active]:text-red-300 text-gray-400">
-                      ���� Top Bearish
+                      🔴 Top Bearish
                     </TabsTrigger>
                     <TabsTrigger value="gainers" className="data-[state=active]:bg-emerald-600/30 data-[state=active]:text-emerald-300 text-gray-400">
                       📈 Biggest Gainers
@@ -1306,7 +1306,7 @@ export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNaviga
                 <Card className="bg-black/40 border-cyan-500/20 backdrop-blur-xl">
                   <CardHeader className="border-b border-cyan-500/20">
                     <CardTitle className="text-white text-sm flex items-center gap-2">
-                      <span className="text-lg">��</span>
+                      <span className="text-lg">⭐</span>
                       Your Crypto Watchlist
                     </CardTitle>
                   </CardHeader>

--- a/client/src/components/FuturisticHomepage.tsx
+++ b/client/src/components/FuturisticHomepage.tsx
@@ -100,9 +100,10 @@ interface TrendingTopic {
 
 interface FuturisticHomepageProps {
   onNavigate?: (section: string) => void;
+  initialSection?: string;
 }
 
-export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNavigate }) => {
+export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNavigate, initialSection }) => {
   const { setMoodScore, themeMode, cardBackground, borderColor } = useMoodTheme();
   const [activeSection, setActiveSection] = useState<'home' | 'market-mood' | 'watchlist' | 'news-feed' | 'community' | 'chat' | 'space' | 'rooms' | 'tool' | 'market' | 'crypto' | 'charts' | 'trending' | 'earnings' | 'finance' | 'screener' | 'trade-journal' | 'sentiment-polls'>('home');
   const [activeToolSubtab, setActiveToolSubtab] = useState("Market");
@@ -878,7 +879,7 @@ export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNaviga
                       ����� Top Bullish
                     </TabsTrigger>
                     <TabsTrigger value="bearish" className="data-[state=active]:bg-red-600/30 data-[state=active]:text-red-300 text-gray-400">
-                      🔴 Top Bearish
+                      ���� Top Bearish
                     </TabsTrigger>
                     <TabsTrigger value="gainers" className="data-[state=active]:bg-emerald-600/30 data-[state=active]:text-emerald-300 text-gray-400">
                       📈 Biggest Gainers
@@ -1305,7 +1306,7 @@ export const FuturisticHomepage: React.FC<FuturisticHomepageProps> = ({ onNaviga
                 <Card className="bg-black/40 border-cyan-500/20 backdrop-blur-xl">
                   <CardHeader className="border-b border-cyan-500/20">
                     <CardTitle className="text-white text-sm flex items-center gap-2">
-                      <span className="text-lg">⭐</span>
+                      <span className="text-lg">��</span>
                       Your Crypto Watchlist
                     </CardTitle>
                   </CardHeader>


### PR DESCRIPTION
## Purpose
Restore the finance hub subtab to its previous appearance and functionality as requested by the user. The finance tab should display the original interface instead of the BuilderFinanceDemo component.

## Code changes
- **App.tsx**: Changed finance route from `BuilderFinanceDemo` to `FuturisticHomepage` with finance as initial section
- **FuturisticHomepage.tsx**: Added `initialSection` prop to allow setting the default active section
- Added useEffect hook to handle the initialSection prop and set the active section accordingly
- Updated component interface and state initialization to support the new prop

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 60`

🔗 [Edit in Builder.io](https://builder.io/app/projects/56f4348cf8de47ef89a601d8ef438566/vibe-works)

👀 [Preview Link](https://56f4348cf8de47ef89a601d8ef438566-vibe-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>56f4348cf8de47ef89a601d8ef438566</projectId>-->
<!--<branchName>vibe-works</branchName>-->